### PR TITLE
fix: Quick-fill weight overwrites all sets (#1)

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -37,12 +37,13 @@ export function ExerciseRow({ exercise, onUpdateSet, onAddSet, onRemoveSet, onQu
       </div>
 
       <div class="quick-fill-row">
-        <label class="quick-fill-label">Weight</label>
+        <label class="quick-fill-label" for={`quick-fill-${exercise.exercise_id}-${exercise.exercise_order}`}>Weight</label>
         <input
+          id={`quick-fill-${exercise.exercise_id}-${exercise.exercise_order}`}
           class="form-input quick-fill-input"
           type="number"
           inputMode="decimal"
-          placeholder="Quick-fill lbs"
+          placeholder="Fill all sets (lbs)"
           value={exercise.quickFillWeight}
           onInput={(e) => onQuickFillWeight((e.target as HTMLInputElement).value)}
         />

--- a/frontend/src/components/workout/quick-fill.test.ts
+++ b/frontend/src/components/workout/quick-fill.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { applyQuickFillWeight } from './quick-fill';
+import type { TrackerExercise } from './exercise-row';
+import type { TrackerSet } from './set-row';
+
+function makeSet(overrides: Partial<TrackerSet> = {}): TrackerSet {
+  return {
+    set_number: 1,
+    planned_reps: '8-10',
+    weight: '',
+    reps: '',
+    effort: '',
+    notes: '',
+    saved: false,
+    sheetRow: -1,
+    ...overrides,
+  };
+}
+
+function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise {
+  return {
+    exercise_id: 'ex1',
+    exercise_name: 'Bench Press',
+    section: 'primary',
+    exercise_order: 1,
+    sets: [makeSet({ set_number: 1 }), makeSet({ set_number: 2 }), makeSet({ set_number: 3 })],
+    quickFillWeight: '',
+    ...overrides,
+  };
+}
+
+describe('applyQuickFillWeight', () => {
+  // AC1: Quick fill overwrites pre-filled set weights
+  it('overwrites pre-filled set weights with new value', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, weight: '135', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, weight: '135', saved: true, sheetRow: 3 }),
+        makeSet({ set_number: 3, weight: '140', saved: true, sheetRow: 4 }),
+      ],
+    })];
+
+    const result = applyQuickFillWeight(exercises, 'ex1', 1, '155');
+
+    expect(result[0].quickFillWeight).toBe('155');
+    expect(result[0].sets[0].weight).toBe('155');
+    expect(result[0].sets[1].weight).toBe('155');
+    expect(result[0].sets[2].weight).toBe('155');
+    // Overwritten sets should be marked unsaved
+    expect(result[0].sets[0].saved).toBe(false);
+    expect(result[0].sets[1].saved).toBe(false);
+    expect(result[0].sets[2].saved).toBe(false);
+  });
+
+  // AC2: Quick fill still works on fresh (empty) sets
+  it('fills empty sets with weight value', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, weight: '' }),
+        makeSet({ set_number: 2, weight: '' }),
+      ],
+    })];
+
+    const result = applyQuickFillWeight(exercises, 'ex1', 1, '185');
+
+    expect(result[0].sets[0].weight).toBe('185');
+    expect(result[0].sets[1].weight).toBe('185');
+  });
+
+  // AC3: Clearing quick fill does not wipe individual set weights
+  it('does not clear existing set weights when quick fill is cleared', () => {
+    const exercises = [makeExercise({
+      quickFillWeight: '135',
+      sets: [
+        makeSet({ set_number: 1, weight: '135', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, weight: '135', saved: true, sheetRow: 3 }),
+      ],
+    })];
+
+    const result = applyQuickFillWeight(exercises, 'ex1', 1, '');
+
+    expect(result[0].quickFillWeight).toBe('');
+    // Set weights should NOT be cleared
+    expect(result[0].sets[0].weight).toBe('135');
+    expect(result[0].sets[1].weight).toBe('135');
+    // Saved status should be preserved
+    expect(result[0].sets[0].saved).toBe(true);
+    expect(result[0].sets[1].saved).toBe(true);
+  });
+
+  it('only affects the matching exercise', () => {
+    const exercises = [
+      makeExercise({ exercise_id: 'ex1', exercise_order: 1 }),
+      makeExercise({ exercise_id: 'ex2', exercise_order: 2, exercise_name: 'Squat' }),
+    ];
+
+    const result = applyQuickFillWeight(exercises, 'ex1', 1, '200');
+
+    expect(result[0].sets[0].weight).toBe('200');
+    // Second exercise untouched
+    expect(result[1].sets[0].weight).toBe('');
+    expect(result[1].quickFillWeight).toBe('');
+  });
+
+  it('handles mixed pre-filled and empty sets', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, weight: '135' }),
+        makeSet({ set_number: 2, weight: '' }),
+        makeSet({ set_number: 3, weight: '140' }),
+      ],
+    })];
+
+    const result = applyQuickFillWeight(exercises, 'ex1', 1, '155');
+
+    // All sets should have the new weight
+    expect(result[0].sets[0].weight).toBe('155');
+    expect(result[0].sets[1].weight).toBe('155');
+    expect(result[0].sets[2].weight).toBe('155');
+  });
+});

--- a/frontend/src/components/workout/quick-fill.ts
+++ b/frontend/src/components/workout/quick-fill.ts
@@ -1,0 +1,25 @@
+import type { TrackerExercise } from './exercise-row';
+
+/**
+ * Apply quick-fill weight to all sets for a matching exercise.
+ * When weight is non-empty, overwrites all set weights.
+ * When weight is empty, only updates the quickFillWeight field (preserves existing set weights).
+ */
+export function applyQuickFillWeight(
+  exercises: TrackerExercise[],
+  exerciseId: string,
+  exerciseOrder: number,
+  weight: string,
+): TrackerExercise[] {
+  return exercises.map((ex) => {
+    if (ex.exercise_id !== exerciseId || ex.exercise_order !== exerciseOrder) return ex;
+    return {
+      ...ex,
+      quickFillWeight: weight,
+      sets: ex.sets.map((s) => {
+        if (!weight) return s;
+        return { ...s, weight, saved: false };
+      }),
+    };
+  });
+}

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -8,6 +8,7 @@ import { ExerciseRow } from './exercise-row';
 import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
 import type { ExerciseWithRow, Effort } from '../../api/types';
+import { applyQuickFillWeight } from './quick-fill';
 
 interface Props {
   workoutId: string;
@@ -156,25 +157,21 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
   };
 
   const handleQuickFillWeight = (exerciseId: string, exerciseOrder: number, weight: string) => {
-    setExerciseList((prev) =>
-      prev.map((ex) => {
-        if (ex.exercise_id !== exerciseId || ex.exercise_order !== exerciseOrder) return ex;
-        return {
-          ...ex,
-          quickFillWeight: weight,
-          sets: ex.sets.map((s) => {
-            // Only fill empty weight fields
-            if (s.weight) return s;
-            const updated = { ...s, weight, saved: false };
-            // Schedule save for filled sets that have reps
-            if (weight && s.reps) {
-              setTimeout(() => debouncedSave(exerciseOrder, exerciseId, updated), 0);
+    setExerciseList((prev) => {
+      const next = applyQuickFillWeight(prev, exerciseId, exerciseOrder, weight);
+      // Schedule save for filled sets that have reps
+      if (weight) {
+        const ex = next.find((e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder);
+        if (ex) {
+          for (const s of ex.sets) {
+            if (s.reps) {
+              setTimeout(() => debouncedSave(exerciseOrder, exerciseId, s), 0);
             }
-            return updated;
-          }),
-        };
-      }),
-    );
+          }
+        }
+      }
+      return next;
+    });
   };
 
   const handleAddSet = (exerciseId: string, exerciseOrder: number) => {

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1205,7 +1205,7 @@ input, select, textarea {
 
 .quick-fill-input {
   flex: 1;
-  min-height: 36px;
+  min-height: 44px;
   padding: var(--space-xs) var(--space-sm);
   font-size: var(--text-sm);
 }


### PR DESCRIPTION
Closes #1

## Changes
- **Logic fix:** Extracted `applyQuickFillWeight()` pure function — when quick-fill value is non-empty, overwrites all set weights (not just empty ones). Clearing the input preserves existing set weights.
- **A11y:** Added `for`/`id` association between quick-fill label and input (unique per exercise).
- **Touch target:** Increased `.quick-fill-input` min-height from 36px → 44px.
- **Placeholder:** Updated from "Quick-fill lbs" → "Fill all sets (lbs)" to clarify overwrite behaviour.

## Test plan
- [x] 5 new unit tests covering all 4 ACs + mixed pre-filled/empty edge case
- [ ] QA in demo mode: start workout from template, verify quick-fill updates all weights
- [ ] QA: clear quick-fill input, verify set weights preserved
- [ ] Verify label/input association with screen reader or dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)