### PR TITLE
feat: Warmup exercises as list-only cards (#2)

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -24,6 +24,25 @@ function sectionBadgeClass(section: string): string {
 }
 
 export function ExerciseRow({ exercise, onUpdateSet, onAddSet, onRemoveSet, onQuickFillWeight }: Props) {
+  const isWarmup = exercise.section === 'warmup';
+
+  // Warmup exercises render as simplified name-only cards
+  if (isWarmup) {
+    return (
+      <div
+        class="tracker-exercise tracker-exercise-warmup"
+        aria-label={`Warmup: ${exercise.exercise_name} (list only)`}
+      >
+        <div class="tracker-exercise-header">
+          <span class={sectionBadgeClass(exercise.section)}>
+            {exercise.section}
+          </span>
+          <span class="tracker-exercise-name">{exercise.exercise_name}</span>
+        </div>
+      </div>
+    );
+  }
+
   const isSS = exercise.section.startsWith('SS');
   const cardClass = `tracker-exercise${isSS ? ` section-ss-group ss-${exercise.section}` : ''}`;
 

--- a/frontend/src/components/workout/warmup.test.ts
+++ b/frontend/src/components/workout/warmup.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { isWarmupExercise } from './warmup';
+import type { TrackerExercise } from './exercise-row';
+import type { TrackerSet } from './set-row';
+
+function makeSet(overrides: Partial<TrackerSet> = {}): TrackerSet {
+  return {
+    set_number: 1,
+    planned_reps: '',
+    weight: '',
+    reps: '',
+    effort: '',
+    notes: '',
+    saved: false,
+    sheetRow: -1,
+    ...overrides,
+  };
+}
+
+function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise {
+  return {
+    exercise_id: 'ex1',
+    exercise_name: 'Push Ups',
+    section: 'warmup',
+    exercise_order: 1,
+    sets: [],
+    quickFillWeight: '',
+    ...overrides,
+  };
+}
+
+describe('isWarmupExercise', () => {
+  // AC1: warmup exercises are identified by section
+  it('returns true for section "warmup"', () => {
+    expect(isWarmupExercise(makeExercise({ section: 'warmup' }))).toBe(true);
+  });
+
+  // AC2: non-warmup sections return false
+  it('returns false for section "primary"', () => {
+    expect(isWarmupExercise(makeExercise({ section: 'primary' }))).toBe(false);
+  });
+
+  it('returns false for superset sections', () => {
+    expect(isWarmupExercise(makeExercise({ section: 'SS1' }))).toBe(false);
+    expect(isWarmupExercise(makeExercise({ section: 'SS2' }))).toBe(false);
+  });
+
+  it('returns false for burnout section', () => {
+    expect(isWarmupExercise(makeExercise({ section: 'burnout' }))).toBe(false);
+  });
+
+  it('returns false for cooldown section', () => {
+    expect(isWarmupExercise(makeExercise({ section: 'cooldown' }))).toBe(false);
+  });
+});
+
+describe('warmup filtering for save', () => {
+  // AC3: warmup exercises should be filtered out before saving
+  it('filters warmup exercises from save list', () => {
+    const exercises: TrackerExercise[] = [
+      makeExercise({ exercise_id: 'ex1', section: 'warmup', exercise_order: 1 }),
+      makeExercise({
+        exercise_id: 'ex2',
+        section: 'primary',
+        exercise_order: 2,
+        exercise_name: 'Bench Press',
+        sets: [makeSet({ set_number: 1, weight: '135', reps: '10' })],
+      }),
+      makeExercise({ exercise_id: 'ex3', section: 'warmup', exercise_order: 3 }),
+      makeExercise({
+        exercise_id: 'ex4',
+        section: 'SS1',
+        exercise_order: 4,
+        exercise_name: 'Cable Fly',
+        sets: [makeSet({ set_number: 1, weight: '30', reps: '12' })],
+      }),
+    ];
+
+    const saveable = exercises.filter((ex) => !isWarmupExercise(ex));
+    expect(saveable).toHaveLength(2);
+    expect(saveable[0].exercise_name).toBe('Bench Press');
+    expect(saveable[1].exercise_name).toBe('Cable Fly');
+  });
+});

--- a/frontend/src/components/workout/warmup.ts
+++ b/frontend/src/components/workout/warmup.ts
@@ -1,0 +1,6 @@
+import type { TrackerExercise } from './exercise-row';
+
+/** Returns true if the exercise is a warmup (list-only, no set tracking). */
+export function isWarmupExercise(exercise: TrackerExercise): boolean {
+  return exercise.section === 'warmup';
+}

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
-import { activeWorkoutSets } from '../../state/store';
+import { activeWorkoutSets, activeWarmupExercises } from '../../state/store';
 import { saveSet, removeSet, finishWorkout, deleteWorkout } from '../../state/actions';
 import { useAuth } from '../../auth/auth-context';
 import { navigate } from '../../router/router';
@@ -9,6 +9,7 @@ import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
 import type { ExerciseWithRow, Effort } from '../../api/types';
 import { applyQuickFillWeight } from './quick-fill';
+import { isWarmupExercise } from './warmup';
 
 interface Props {
   workoutId: string;
@@ -63,9 +64,19 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
   const [showFinishForm, setShowFinishForm] = useState(false);
   const saveTimers = useRef<Map<string, number>>(new Map());
 
-  // Initialize from signal
+  // Initialize from signal, merging warmup exercises (list-only, no sets)
   useEffect(() => {
-    setExerciseList(buildExerciseList(activeWorkoutSets.value));
+    const tracked = buildExerciseList(activeWorkoutSets.value);
+    const warmups: TrackerExercise[] = activeWarmupExercises.value.map((w) => ({
+      exercise_id: w.exercise_id,
+      exercise_name: w.exercise_name,
+      section: 'warmup',
+      exercise_order: w.exercise_order,
+      sets: [],
+      quickFillWeight: '',
+    }));
+    const merged = [...warmups, ...tracked].sort((a, b) => a.exercise_order - b.exercise_order);
+    setExerciseList(merged);
   }, []);
 
   // Debounced save for a specific set
@@ -272,8 +283,9 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
     try {
       await flushPendingSaves();
 
-      // Save any unsaved sets with data
+      // Save any unsaved sets with data (skip warmup exercises — they are list-only)
       for (const ex of exerciseList) {
+        if (isWarmupExercise(ex)) continue;
         for (const set of ex.sets) {
           if (!set.saved && (set.weight || set.reps)) {
             await saveSet({

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1177,6 +1177,23 @@ input, select, textarea {
   padding: var(--space-md);
 }
 
+/* Warmup exercises — simplified list-only card */
+.tracker-exercise-warmup {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  border-left: 3px solid #e65100;
+  padding: var(--space-sm) var(--space-md);
+}
+
+.tracker-exercise-warmup .tracker-exercise-header {
+  margin-bottom: 0;
+}
+
+[data-theme="dark"] .tracker-exercise-warmup {
+  border-left-color: #ffb74d;
+}
+
 .tracker-exercise-header {
   display: flex;
   align-items: center;

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -1,4 +1,4 @@
-import { exercises, templates, workouts, sets, loading, activeWorkoutId, activeWorkoutSets, showToast } from './store';
+import { exercises, templates, workouts, sets, loading, activeWorkoutId, activeWorkoutSets, activeWarmupExercises, showToast } from './store';
 import { fetchExercises, createExercise, updateExercise as updateExerciseApi, deleteExercise as deleteExerciseApi } from '../api/exercises-api';
 import { fetchTemplateRows, groupTemplateRows, createTemplate as createTemplateApi, updateTemplate as updateTemplateApi, deleteTemplate as deleteTemplateApi } from '../api/templates-api';
 import { fetchWorkouts, fetchSets, createWorkout as createWorkoutApi, updateWorkout as updateWorkoutApi, deleteWorkoutRows, appendSet as appendSetApi, appendSets as appendSetsApi, updateSet as updateSetApi, deleteSetRow } from '../api/workouts-api';
@@ -183,6 +183,7 @@ export async function startWorkout(
       await prepopulateSetsFromTemplate(workout.id, data.template_id, token);
     } else {
       activeWorkoutSets.value = [];
+      activeWarmupExercises.value = [];
     }
 
     return workout.id;
@@ -205,12 +206,21 @@ async function prepopulateSetsFromTemplate(
   }
 
   const newSets: WorkoutSet[] = [];
-  for (const ex of tpl.exercises) {
-    const setCount = parseSetCount(ex.sets);
-    // Warmup exercises get 1 set by default if no sets specified
-    const count = ex.section === 'warmup' && !ex.sets.trim() ? 1 : setCount;
+  const warmups: { exercise_id: string; exercise_name: string; exercise_order: number }[] = [];
 
-    for (let s = 1; s <= count; s++) {
+  for (const ex of tpl.exercises) {
+    // Warmup exercises are list-only — no set rows generated
+    if (ex.section === 'warmup') {
+      warmups.push({
+        exercise_id: ex.exercise_id,
+        exercise_name: ex.exercise_name,
+        exercise_order: ex.order,
+      });
+      continue;
+    }
+
+    const setCount = parseSetCount(ex.sets);
+    for (let s = 1; s <= setCount; s++) {
       newSets.push({
         workout_id: workoutId,
         exercise_id: ex.exercise_id,
@@ -226,6 +236,8 @@ async function prepopulateSetsFromTemplate(
       });
     }
   }
+
+  activeWarmupExercises.value = warmups;
 
   // Batch append to Sheets
   await appendSetsApi(newSets, token);

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -8,9 +8,17 @@ export const workouts = signal<WorkoutWithRow[]>([]);
 export const sets = signal<SetWithRow[]>([]);
 export const loading = signal(true);
 
+// Warmup exercise metadata (no sets — display only in tracker)
+export interface WarmupExerciseInfo {
+  exercise_id: string;
+  exercise_name: string;
+  exercise_order: number;
+}
+
 // UI state
 export const activeWorkoutId = signal<string | null>(null);
 export const activeWorkoutSets = signal<SetWithRow[]>([]);
+export const activeWarmupExercises = signal<WarmupExerciseInfo[]>([]);
 export const filterType = signal<WorkoutType | null>(null);
 export const filterTags = signal<string[]>([]);
 


### PR DESCRIPTION
Closes #2

## Changes
- **ExerciseRow:** Conditional render — warmup exercises show simplified card (badge + name only) with `aria-label`, `min-height: 44px`, and left border accent using warmup color palette. No quick-fill, set rows, or add set button.
- **WorkoutTracker:** Merges warmup exercises from `activeWarmupExercises` signal into the exercise list. Skips warmup exercises in `handleFinish` save loop.
- **actions.ts:** `prepopulateSetsFromTemplate` skips warmup exercises entirely (no set rows generated), stores warmup metadata in `activeWarmupExercises` signal.
- **store.ts:** New `activeWarmupExercises` signal for warmup exercise display data.
- **global.css:** `.tracker-exercise-warmup` styling with min-height 44px, left border accent, light/dark theme support.

## Test plan
- [x] 6 new unit tests for warmup identification and save filtering
- [x] 65/65 tests pass, tsc clean, build clean
- [ ] QA: Start workout from template with warmups, verify list-only rendering
- [ ] QA: Verify non-warmup exercises still have full tracking UI
- [ ] QA: Finish workout, verify no warmup rows saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)