### PR TITLE
feat: label management system with colors and quick-assign

### DIFF
--- a/frontend/src/api/demo-data.ts
+++ b/frontend/src/api/demo-data.ts
@@ -1,6 +1,7 @@
 // Demo mode detection and seed data for offline/preview usage.
 
-import type { ExerciseWithRow, TemplateRowWithRow, Template, WorkoutWithRow, SetWithRow } from './types';
+import type { ExerciseWithRow, LabelWithRow, TemplateRowWithRow, Template, WorkoutWithRow, SetWithRow } from './types';
+import { colorKeyFromName } from './label-colors';
 
 let _isDemo: boolean | null = null;
 
@@ -31,6 +32,26 @@ export const DEMO_EXERCISES: ExerciseWithRow[] = [
   { id: 'ex_demo015', name: 'BB Overhead Press', tags: 'Push, Shoulders, Compound', notes: '', created: '2025-01-01T00:00:00.000Z', sheetRow: 16 },
   { id: 'ex_demo_pushup', name: 'Push Ups', tags: 'Push, Chest, Compound', notes: '', created: '2025-01-01T00:00:00.000Z', sheetRow: 17 },
 ];
+
+// Build demo labels from the unique tags in demo exercises
+function buildDemoLabels(): LabelWithRow[] {
+  const tagSet = new Set<string>();
+  for (const ex of DEMO_EXERCISES) {
+    if (ex.tags) {
+      ex.tags.split(',').map(t => t.trim()).filter(Boolean).forEach(t => tagSet.add(t));
+    }
+  }
+  const sorted = Array.from(tagSet).sort();
+  return sorted.map((name, i) => ({
+    id: `lbl_demo${String(i + 1).padStart(3, '0')}`,
+    name,
+    color_key: colorKeyFromName(name),
+    created: '2025-01-01T00:00:00.000Z',
+    sheetRow: i + 2,
+  }));
+}
+
+export const DEMO_LABELS: LabelWithRow[] = buildDemoLabels();
 
 const now = '2025-01-15T00:00:00.000Z';
 

--- a/frontend/src/api/label-colors.test.ts
+++ b/frontend/src/api/label-colors.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { LABEL_COLORS, getLabelColor, colorKeyFromName } from './label-colors';
+
+describe('LABEL_COLORS', () => {
+  it('defines exactly 10 colors', () => {
+    expect(LABEL_COLORS).toHaveLength(10);
+  });
+
+  it('each color has required fields', () => {
+    for (const c of LABEL_COLORS) {
+      expect(c.key).toBeTruthy();
+      expect(c.name).toBeTruthy();
+      expect(c.light.bg).toBeTruthy();
+      expect(c.light.text).toBeTruthy();
+      expect(c.dark.bg).toBeTruthy();
+      expect(c.dark.text).toBeTruthy();
+    }
+  });
+
+  it('has unique keys', () => {
+    const keys = LABEL_COLORS.map(c => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe('getLabelColor', () => {
+  it('returns a color by key', () => {
+    const red = getLabelColor('red');
+    expect(red).toBeDefined();
+    expect(red!.name).toBe('Red');
+  });
+
+  it('returns undefined for unknown key', () => {
+    expect(getLabelColor('neon')).toBeUndefined();
+  });
+});
+
+describe('colorKeyFromName', () => {
+  it('returns a valid color key', () => {
+    const key = colorKeyFromName('Push');
+    const validKeys = LABEL_COLORS.map(c => c.key);
+    expect(validKeys).toContain(key);
+  });
+
+  it('is deterministic — same name always gives same color', () => {
+    const key1 = colorKeyFromName('Legs');
+    const key2 = colorKeyFromName('Legs');
+    expect(key1).toBe(key2);
+  });
+
+  it('different names can map to different colors', () => {
+    // Not guaranteed for all pairs, but for these common ones they should differ
+    const pushKey = colorKeyFromName('Push');
+    const pullKey = colorKeyFromName('Pull');
+    // At least verify both are valid keys
+    const validKeys = LABEL_COLORS.map(c => c.key);
+    expect(validKeys).toContain(pushKey);
+    expect(validKeys).toContain(pullKey);
+  });
+});

--- a/frontend/src/api/label-colors.ts
+++ b/frontend/src/api/label-colors.ts
@@ -1,0 +1,36 @@
+// Predefined label color palette — 10 colors with light + dark theme pairs.
+
+export interface LabelColor {
+  key: string;
+  name: string;
+  light: { bg: string; text: string };
+  dark: { bg: string; text: string };
+}
+
+export const LABEL_COLORS: LabelColor[] = [
+  { key: 'red',     name: 'Red',     light: { bg: '#fde8e8', text: '#c53030' }, dark: { bg: '#3b1515', text: '#fca5a5' } },
+  { key: 'orange',  name: 'Orange',  light: { bg: '#fff3e0', text: '#e65100' }, dark: { bg: '#2d1b06', text: '#ffb74d' } },
+  { key: 'amber',   name: 'Amber',   light: { bg: '#fef7e8', text: '#b45309' }, dark: { bg: '#2d2210', text: '#fbbf24' } },
+  { key: 'green',   name: 'Green',   light: { bg: '#e8f5e9', text: '#2e7d32' }, dark: { bg: '#14291a', text: '#86efac' } },
+  { key: 'teal',    name: 'Teal',    light: { bg: '#e0f2f1', text: '#00695c' }, dark: { bg: '#0a2623', text: '#80cbc4' } },
+  { key: 'blue',    name: 'Blue',    light: { bg: '#e3f2fd', text: '#1565c0' }, dark: { bg: '#0d1f33', text: '#93c5fd' } },
+  { key: 'indigo',  name: 'Indigo',  light: { bg: '#eef1fe', text: '#3b5de5' }, dark: { bg: '#1e2440', text: '#a5b4fc' } },
+  { key: 'purple',  name: 'Purple',  light: { bg: '#f3e5f5', text: '#7b1fa2' }, dark: { bg: '#2a1533', text: '#d8b4fe' } },
+  { key: 'pink',    name: 'Pink',    light: { bg: '#fce4ec', text: '#c62828' }, dark: { bg: '#2d0a0a', text: '#f9a8d4' } },
+  { key: 'gray',    name: 'Gray',    light: { bg: '#f0f2f4', text: '#5f6b7a' }, dark: { bg: '#25252b', text: '#9ba1a6' } },
+];
+
+/** Get a LabelColor by key, or undefined if not found. */
+export function getLabelColor(key: string): LabelColor | undefined {
+  return LABEL_COLORS.find(c => c.key === key);
+}
+
+/** Deterministic color assignment: hash a string to a palette index. */
+export function colorKeyFromName(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % LABEL_COLORS.length;
+  return LABEL_COLORS[index].key;
+}

--- a/frontend/src/api/labels-api.ts
+++ b/frontend/src/api/labels-api.ts
@@ -1,0 +1,73 @@
+// Labels domain API — wraps Sheets REST calls with demo-mode fallback.
+
+import type { Label, LabelWithRow } from './types';
+import { sheetsGet, sheetsAppend, sheetsUpdate, sheetsDeleteRow, getSheetId, withReauth } from './sheets';
+import { isDemo, DEMO_LABELS } from './demo-data';
+
+export async function fetchLabels(token: string): Promise<LabelWithRow[]> {
+  if (isDemo()) return [...DEMO_LABELS];
+
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Labels!A2:D', t);
+    return rows.map((row, i) => ({
+      id: row[0] || '',
+      name: row[1] || '',
+      color_key: row[2] || '',
+      created: row[3] || '',
+      sheetRow: i + 2,
+    }));
+  });
+}
+
+export async function createLabel(
+  data: { name: string; color_key: string },
+  token: string,
+): Promise<Label> {
+  const id = `lbl_${crypto.randomUUID().slice(0, 8)}`;
+  const created = new Date().toISOString();
+  const label: Label = { id, name: data.name, color_key: data.color_key, created };
+
+  if (isDemo()) return label;
+
+  await withReauth(token, (t) =>
+    sheetsAppend('Labels!A:D', [[id, data.name, data.color_key, created]], t),
+  );
+  return label;
+}
+
+export async function updateLabel(
+  sheetRow: number,
+  label: Label,
+  token: string,
+): Promise<void> {
+  if (isDemo()) return;
+
+  await withReauth(token, (t) =>
+    sheetsUpdate(
+      `Labels!A${sheetRow}:D${sheetRow}`,
+      [[label.id, label.name, label.color_key, label.created]],
+      t,
+    ),
+  );
+}
+
+export async function deleteLabel(sheetRow: number, token: string): Promise<void> {
+  if (isDemo()) return;
+
+  await withReauth(token, async (t) => {
+    const sheetId = await getSheetId('Labels', t);
+    await sheetsDeleteRow(sheetId, sheetRow, t);
+  });
+}
+
+export async function appendLabels(
+  labelsData: { id: string; name: string; color_key: string; created: string }[],
+  token: string,
+): Promise<void> {
+  if (isDemo()) return;
+
+  const values = labelsData.map(l => [l.id, l.name, l.color_key, l.created]);
+  await withReauth(token, (t) =>
+    sheetsAppend('Labels!A:D', values, t),
+  );
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -64,6 +64,14 @@ export interface WorkoutSet {
 }
 export interface SetWithRow extends WorkoutSet { sheetRow: number; }
 
+export interface Label {
+  id: string;
+  name: string;
+  color_key: string;
+  created: string;
+}
+export interface LabelWithRow extends Label { sheetRow: number; }
+
 export interface UserInfo {
   email: string;
   name: string;

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -13,6 +13,7 @@ import { SettingsScreen } from './components/settings/settings-screen';
 import { ExercisesScreen } from './components/exercises/exercises-screen';
 import { WorkoutFlow } from './components/workout/workout-flow';
 import { WorkoutDetail } from './components/history/workout-detail';
+import { ManageLabelsScreen } from './components/settings/manage-labels-screen';
 
 function Router() {
   const route = currentRoute.value;
@@ -34,6 +35,8 @@ function Router() {
       return <TemplatesScreen />;
     case 'exercises':
       return <ExercisesScreen />;
+    case 'manage-labels':
+      return <ManageLabelsScreen />;
     case 'settings':
       return <SettingsScreen />;
     default:

--- a/frontend/src/components/exercises/add-exercise-modal.tsx
+++ b/frontend/src/components/exercises/add-exercise-modal.tsx
@@ -3,6 +3,7 @@ import { exercises as exercisesSignal, allTags } from '../../state/store';
 import { addExercise } from '../../state/actions';
 import { useAuth } from '../../auth/auth-context';
 import { ExerciseForm } from './exercise-form';
+import { LabelBadge } from '../shared/label-badge';
 import type { ExerciseWithRow } from '../../api/types';
 
 interface AddExerciseModalProps {
@@ -78,14 +79,12 @@ export function AddExerciseModal({ onSelect, onClose }: AddExerciseModalProps) {
             {allTags.value.length > 0 && (
               <div class="tag-filter-row">
                 {allTags.value.map((tag) => (
-                  <button
+                  <LabelBadge
                     key={tag}
-                    type="button"
-                    class={`tag-badge${selectedTags.includes(tag) ? ' active' : ''}`}
+                    name={tag}
+                    active={selectedTags.includes(tag)}
                     onClick={() => toggleTag(tag)}
-                  >
-                    {tag}
-                  </button>
+                  />
                 ))}
               </div>
             )}
@@ -104,9 +103,7 @@ export function AddExerciseModal({ onSelect, onClose }: AddExerciseModalProps) {
                     {ex.tags && (
                       <div class="exercise-list-item-tags">
                         {ex.tags.split(',').map((t) => t.trim()).filter(Boolean).map((tag) => (
-                          <span key={tag} class="tag-badge">
-                            {tag}
-                          </span>
+                          <LabelBadge key={tag} name={tag} />
                         ))}
                       </div>
                     )}

--- a/frontend/src/components/exercises/exercise-form.tsx
+++ b/frontend/src/components/exercises/exercise-form.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef } from 'preact/hooks';
-import { allTags } from '../../state/store';
+import { useState } from 'preact/hooks';
+import { LabelChipGrid } from '../shared/label-chip-grid';
 
 interface ExerciseFormProps {
   initial?: { name: string; tags: string; notes: string };
@@ -15,40 +15,14 @@ export function ExerciseForm({ initial, onSubmit, onCancel, submitLabel = 'Save'
       ? initial.tags.split(',').map((t) => t.trim()).filter(Boolean)
       : [],
   );
-  const [tagInput, setTagInput] = useState('');
   const [notes, setNotes] = useState(initial?.notes ?? '');
   const [submitting, setSubmitting] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  const addTag = (raw: string) => {
-    const tag = raw.trim();
-    if (tag && !tags.includes(tag)) {
-      setTags([...tags, tag]);
-    }
-    setTagInput('');
+  const toggleTag = (tagName: string) => {
+    setTags(prev =>
+      prev.includes(tagName) ? prev.filter(t => t !== tagName) : [...prev, tagName],
+    );
   };
-
-  const removeTag = (tag: string) => {
-    setTags(tags.filter((t) => t !== tag));
-  };
-
-  const handleTagKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault();
-      addTag(tagInput);
-    }
-    if (e.key === 'Backspace' && tagInput === '' && tags.length > 0) {
-      removeTag(tags[tags.length - 1]);
-    }
-  };
-
-  const handleTagBlur = () => {
-    if (tagInput.trim()) addTag(tagInput);
-  };
-
-  const suggestions = allTags.value.filter(
-    (t) => !tags.includes(t) && t.toLowerCase().includes(tagInput.toLowerCase()),
-  );
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -79,48 +53,11 @@ export function ExerciseForm({ initial, onSubmit, onCancel, submitLabel = 'Save'
       </div>
 
       <div class="form-group">
-        <label class="form-label">Tags</label>
-        <div
-          class="tag-input-wrapper"
-          onClick={() => inputRef.current?.focus()}
-        >
-          {tags.map((tag) => (
-            <span key={tag} class="tag-badge tag-badge-removable">
-              {tag}
-              <button
-                type="button"
-                class="tag-badge-remove"
-                onClick={(e) => { e.stopPropagation(); removeTag(tag); }}
-                aria-label={`Remove ${tag}`}
-              >
-                &times;
-              </button>
-            </span>
-          ))}
-          <input
-            ref={inputRef}
-            class="tag-input-field"
-            type="text"
-            value={tagInput}
-            onInput={(e) => setTagInput((e.target as HTMLInputElement).value)}
-            onKeyDown={handleTagKeyDown}
-            onBlur={handleTagBlur}
-            placeholder={tags.length === 0 ? 'Add tags...' : ''}
-          />
-        </div>
-        {tagInput && suggestions.length > 0 && (
-          <div class="tag-suggestions">
-            {suggestions.map((s) => (
-              <span
-                key={s}
-                class="tag-badge tag-suggestion"
-                onClick={() => addTag(s)}
-              >
-                {s}
-              </span>
-            ))}
-          </div>
-        )}
+        <label class="form-label">Labels</label>
+        <LabelChipGrid
+          selected={tags}
+          onToggle={toggleTag}
+        />
       </div>
 
       <div class="form-group">

--- a/frontend/src/components/exercises/exercises-screen.test.ts
+++ b/frontend/src/components/exercises/exercises-screen.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { exercises, allTags } from '../../state/store';
-import type { ExerciseWithRow } from '../../api/types';
+import { exercises, labels, allTags } from '../../state/store';
+import type { ExerciseWithRow, LabelWithRow } from '../../api/types';
 
 const mockExercises: ExerciseWithRow[] = [
   { id: 'ex1', name: 'Bench Press', tags: 'Push, Chest', notes: 'Flat bench', created: '2026-01-01', sheetRow: 2 },
@@ -11,6 +11,7 @@ const mockExercises: ExerciseWithRow[] = [
 describe('ExercisesScreen', () => {
   beforeEach(() => {
     exercises.value = [];
+    labels.value = [];
   });
 
   describe('AC1: /exercises route', () => {
@@ -56,9 +57,13 @@ describe('ExercisesScreen', () => {
       expect(exercises.value.length).toBe(0);
     });
 
-    it('computes allTags from exercises', () => {
-      exercises.value = mockExercises;
-      expect(allTags.value).toEqual(['Back', 'Chest', 'Compound', 'Legs', 'Pull', 'Push']);
+    it('computes allTags from labels signal', () => {
+      labels.value = [
+        { id: 'lbl1', name: 'Back', color_key: 'blue', created: '', sheetRow: 2 },
+        { id: 'lbl2', name: 'Chest', color_key: 'red', created: '', sheetRow: 3 },
+        { id: 'lbl3', name: 'Push', color_key: 'green', created: '', sheetRow: 4 },
+      ];
+      expect(allTags.value).toEqual(['Back', 'Chest', 'Push']);
     });
   });
 

--- a/frontend/src/components/exercises/exercises-screen.tsx
+++ b/frontend/src/components/exercises/exercises-screen.tsx
@@ -3,6 +3,7 @@ import { exercises as exercisesSignal, allTags } from '../../state/store';
 import { editExercise, removeExercise } from '../../state/actions';
 import { useAuth } from '../../auth/auth-context';
 import { ExerciseForm } from './exercise-form';
+import { LabelBadge } from '../shared/label-badge';
 import type { ExerciseWithRow } from '../../api/types';
 
 export function ExercisesScreen() {
@@ -95,14 +96,12 @@ export function ExercisesScreen() {
         {allTags.value.length > 0 && (
           <div class="tag-filter-row">
             {allTags.value.map(tag => (
-              <button
+              <LabelBadge
                 key={tag}
-                type="button"
-                class={`tag-badge${selectedTags.includes(tag) ? ' active' : ''}`}
+                name={tag}
+                active={selectedTags.includes(tag)}
                 onClick={() => toggleTag(tag)}
-              >
-                {tag}
-              </button>
+              />
             ))}
           </div>
         )}
@@ -128,9 +127,7 @@ export function ExercisesScreen() {
                 {ex.tags && (
                   <div class="exercise-list-item-tags">
                     {ex.tags.split(',').map(t => t.trim()).filter(Boolean).map(tag => (
-                      <span key={tag} class="tag-badge">
-                        {tag}
-                      </span>
+                      <LabelBadge key={tag} name={tag} />
                     ))}
                   </div>
                 )}

--- a/frontend/src/components/history/history-filters.tsx
+++ b/frontend/src/components/history/history-filters.tsx
@@ -1,4 +1,5 @@
 import { filterType, filterTags, allTags } from '../../state/store';
+import { LabelBadge } from '../shared/label-badge';
 import type { WorkoutType } from '../../api/types';
 
 const TYPES: { value: WorkoutType; label: string }[] = [
@@ -46,13 +47,12 @@ export function HistoryFilters() {
       {tags.length > 0 && (
         <div class="filter-row tag-filter-row">
           {tags.map((tag) => (
-            <button
+            <LabelBadge
               key={tag}
-              class={`tag-badge${activeTags.includes(tag) ? ' active' : ''}`}
+              name={tag}
+              active={activeTags.includes(tag)}
               onClick={() => toggleTag(tag)}
-            >
-              {tag}
-            </button>
+            />
           ))}
         </div>
       )}

--- a/frontend/src/components/settings/manage-labels-screen.tsx
+++ b/frontend/src/components/settings/manage-labels-screen.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'preact/hooks';
+import { labels, labelUsageCount } from '../../state/store';
+import { addLabel, renameLabel, updateLabelColor, removeLabel } from '../../state/actions';
+import { useAuth } from '../../auth/auth-context';
+import { getLabelColor, LABEL_COLORS } from '../../api/label-colors';
+import { ColorSwatchPicker } from '../shared/color-swatch-picker';
+import { ConfirmModal } from '../shared/confirm-modal';
+import { navigate } from '../../router/router';
+import type { LabelWithRow } from '../../api/types';
+
+export function ManageLabelsScreen() {
+  const { token } = useAuth();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newColor, setNewColor] = useState(LABEL_COLORS[0].key);
+  const [saving, setSaving] = useState(false);
+  const [deletingLabel, setDeletingLabel] = useState<LabelWithRow | null>(null);
+
+  const startEdit = (label: LabelWithRow) => {
+    setEditingId(label.id);
+    setEditName(label.name);
+  };
+
+  const saveEdit = async (label: LabelWithRow) => {
+    if (!token || !editName.trim() || saving) return;
+    if (editName.trim() === label.name) {
+      setEditingId(null);
+      return;
+    }
+    setSaving(true);
+    try {
+      await renameLabel(label, editName.trim(), token);
+      setEditingId(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleColorChange = async (label: LabelWithRow, colorKey: string) => {
+    if (!token || label.color_key === colorKey) return;
+    await updateLabelColor(label, colorKey, token);
+  };
+
+  const handleCreate = async () => {
+    if (!newName.trim() || !token || saving) return;
+    setSaving(true);
+    try {
+      await addLabel({ name: newName.trim(), color_key: newColor }, token);
+      setCreating(false);
+      setNewName('');
+      setNewColor(LABEL_COLORS[0].key);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!token || !deletingLabel) return;
+    await removeLabel(deletingLabel, token);
+    setDeletingLabel(null);
+  };
+
+  const allLabels = labels.value;
+
+  return (
+    <div class="screen manage-labels-screen">
+      <header class="screen-header" style="display: flex; align-items: center; gap: var(--space-sm);">
+        <button
+          type="button"
+          class="template-editor-back"
+          onClick={() => navigate('/settings')}
+        >
+          &larr;
+        </button>
+        <h1>Manage Labels</h1>
+      </header>
+
+      <div class="screen-body">
+        {allLabels.length === 0 && !creating ? (
+          <div class="empty-state">
+            <p>No labels yet.</p>
+            <p>Create one to start organizing your exercises.</p>
+            <button
+              type="button"
+              class="btn btn-primary"
+              style="margin-top: var(--space-md);"
+              onClick={() => setCreating(true)}
+            >
+              New Label
+            </button>
+          </div>
+        ) : (
+          <>
+            <div class="manage-labels-list">
+              {allLabels.map(label => {
+                const color = getLabelColor(label.color_key);
+                const usage = labelUsageCount(label.name);
+                const isEditing = editingId === label.id;
+
+                return (
+                  <div key={label.id} class="manage-label-row">
+                    <div class="manage-label-main">
+                      <span
+                        class="manage-label-swatch"
+                        style={{
+                          background: color ? color.light.text : 'var(--color-primary)',
+                        }}
+                      />
+                      {isEditing ? (
+                        <input
+                          class="form-input manage-label-edit-input"
+                          type="text"
+                          value={editName}
+                          onInput={e => setEditName((e.target as HTMLInputElement).value)}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter') { e.preventDefault(); saveEdit(label); }
+                            if (e.key === 'Escape') setEditingId(null);
+                          }}
+                          onBlur={() => saveEdit(label)}
+                          autoFocus
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          class="manage-label-name"
+                          onClick={() => startEdit(label)}
+                          aria-label={`Rename ${label.name}`}
+                        >
+                          {label.name}
+                        </button>
+                      )}
+                      <span class="manage-label-usage">Used by {usage}</span>
+                      <button
+                        type="button"
+                        class="manage-label-delete"
+                        onClick={() => setDeletingLabel(label)}
+                        aria-label={`Delete ${label.name}`}
+                      >
+                        &times;
+                      </button>
+                    </div>
+                    <ColorSwatchPicker
+                      selected={label.color_key}
+                      onSelect={key => handleColorChange(label, key)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+
+            {creating ? (
+              <div class="manage-label-create-form">
+                <input
+                  class="form-input"
+                  type="text"
+                  value={newName}
+                  onInput={e => setNewName((e.target as HTMLInputElement).value)}
+                  placeholder="New label name"
+                  autoFocus
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') { e.preventDefault(); handleCreate(); }
+                    if (e.key === 'Escape') setCreating(false);
+                  }}
+                />
+                <ColorSwatchPicker selected={newColor} onSelect={setNewColor} />
+                <div class="form-actions">
+                  <button type="button" class="btn btn-secondary" onClick={() => setCreating(false)}>
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-primary"
+                    disabled={saving || !newName.trim()}
+                    onClick={handleCreate}
+                  >
+                    {saving ? 'Creating...' : 'Create'}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                class="btn btn-primary"
+                style="width: 100%;"
+                onClick={() => setCreating(true)}
+              >
+                + New Label
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {deletingLabel && (
+        <ConfirmModal
+          title="Delete Label"
+          message={`Remove '${deletingLabel.name}'? It is used by ${labelUsageCount(deletingLabel.name)} exercises. This cannot be undone.`}
+          confirmLabel="Delete"
+          onConfirm={confirmDelete}
+          onCancel={() => setDeletingLabel(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/manage-labels.test.ts
+++ b/frontend/src/components/settings/manage-labels.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { exercises, labels, allTags, getLabelByName, labelUsageCount } from '../../state/store';
+import { colorKeyFromName, getLabelColor, LABEL_COLORS } from '../../api/label-colors';
+import type { ExerciseWithRow, LabelWithRow } from '../../api/types';
+
+function resetSignals() {
+  exercises.value = [];
+  labels.value = [];
+}
+
+function makeExercise(overrides: Partial<ExerciseWithRow> = {}): ExerciseWithRow {
+  return {
+    id: 'ex1', name: 'Bench Press', tags: 'Push, Chest', notes: '',
+    created: '2025-01-01T00:00:00.000Z', sheetRow: 2, ...overrides,
+  };
+}
+
+function makeLabel(overrides: Partial<LabelWithRow> = {}): LabelWithRow {
+  return {
+    id: 'lbl1', name: 'Push', color_key: 'red',
+    created: '2025-01-01T00:00:00.000Z', sheetRow: 2, ...overrides,
+  };
+}
+
+describe('AC1: Label metadata storage and migration', () => {
+  beforeEach(resetSignals);
+
+  it('allTags is sourced from labels signal, not exercises', () => {
+    exercises.value = [makeExercise({ tags: 'Push, Chest' })];
+    labels.value = [
+      makeLabel({ name: 'Arms', color_key: 'red' }),
+    ];
+    // allTags should reflect labels, not exercise tags
+    expect(allTags.value).toEqual(['Arms']);
+  });
+
+  it('deterministic color assignment: same name always yields same color', () => {
+    const key1 = colorKeyFromName('Push');
+    const key2 = colorKeyFromName('Push');
+    expect(key1).toBe(key2);
+    expect(LABEL_COLORS.map(c => c.key)).toContain(key1);
+  });
+
+  it('migration populates labels from unique exercise tags', () => {
+    // Simulate what bootstrapLabels does
+    const exerciseData = [
+      makeExercise({ tags: 'Push, Chest' }),
+      makeExercise({ id: 'ex2', tags: 'Pull, Chest', sheetRow: 3 }),
+    ];
+    const tagSet = new Set<string>();
+    for (const ex of exerciseData) {
+      ex.tags.split(',').map(t => t.trim()).filter(Boolean).forEach(t => tagSet.add(t));
+    }
+    const sorted = Array.from(tagSet).sort();
+    const migrated = sorted.map((name, i) => ({
+      id: `lbl_${i}`, name, color_key: colorKeyFromName(name),
+      created: '', sheetRow: i + 2,
+    }));
+
+    expect(migrated).toHaveLength(3); // Chest, Pull, Push
+    expect(migrated.map(l => l.name)).toEqual(['Chest', 'Pull', 'Push']);
+    // Each should have a valid color_key
+    for (const l of migrated) {
+      expect(LABEL_COLORS.map(c => c.key)).toContain(l.color_key);
+    }
+  });
+});
+
+describe('AC2: Manage Labels page', () => {
+  beforeEach(resetSignals);
+
+  it('labels signal provides list data for the manage labels screen', () => {
+    labels.value = [
+      makeLabel({ name: 'Push', color_key: 'red' }),
+      makeLabel({ name: 'Pull', color_key: 'blue', id: 'lbl2', sheetRow: 3 }),
+    ];
+    expect(labels.value).toHaveLength(2);
+  });
+
+  it('labelUsageCount returns correct count for each label', () => {
+    labels.value = [
+      makeLabel({ name: 'Push' }),
+      makeLabel({ name: 'Pull', id: 'lbl2', sheetRow: 3 }),
+    ];
+    exercises.value = [
+      makeExercise({ id: 'ex1', tags: 'Push, Chest' }),
+      makeExercise({ id: 'ex2', tags: 'Push, Arms', sheetRow: 3 }),
+      makeExercise({ id: 'ex3', tags: 'Pull, Back', sheetRow: 4 }),
+    ];
+
+    expect(labelUsageCount('Push')).toBe(2);
+    expect(labelUsageCount('Pull')).toBe(1);
+  });
+
+  it('empty state when no labels exist', () => {
+    expect(labels.value).toHaveLength(0);
+  });
+});
+
+describe('AC3: Create, rename, and delete labels', () => {
+  beforeEach(resetSignals);
+
+  it('adding a label updates the labels signal', () => {
+    labels.value = [];
+    const newLabel = makeLabel({ id: 'lbl_new', name: 'Core', color_key: 'green' });
+    labels.value = [...labels.value, newLabel];
+    expect(labels.value).toHaveLength(1);
+    expect(labels.value[0].name).toBe('Core');
+  });
+
+  it('renaming a label updates exercises containing that tag', () => {
+    labels.value = [makeLabel({ name: 'Push' })];
+    exercises.value = [
+      makeExercise({ id: 'ex1', tags: 'Push, Chest' }),
+      makeExercise({ id: 'ex2', tags: 'Pull, Back', sheetRow: 3 }),
+    ];
+
+    // Simulate rename propagation
+    const oldName = 'Push';
+    const newName = 'Pressing';
+    const affected = exercises.value.filter(ex =>
+      ex.tags.split(',').map(t => t.trim()).includes(oldName),
+    );
+    expect(affected).toHaveLength(1);
+
+    // Simulate updating affected exercises
+    exercises.value = exercises.value.map(ex => {
+      const tags = ex.tags.split(',').map(t => t.trim());
+      if (tags.includes(oldName)) {
+        return { ...ex, tags: tags.map(t => t === oldName ? newName : t).join(', ') };
+      }
+      return ex;
+    });
+
+    expect(exercises.value[0].tags).toBe('Pressing, Chest');
+    expect(exercises.value[1].tags).toBe('Pull, Back'); // unchanged
+  });
+
+  it('deleting a label removes it from all exercises', () => {
+    labels.value = [makeLabel({ name: 'Push' })];
+    exercises.value = [
+      makeExercise({ id: 'ex1', tags: 'Push, Chest' }),
+      makeExercise({ id: 'ex2', tags: 'Push', sheetRow: 3 }),
+    ];
+
+    // Simulate delete propagation
+    const labelName = 'Push';
+    exercises.value = exercises.value.map(ex => {
+      const tags = ex.tags.split(',').map(t => t.trim()).filter(t => t !== labelName);
+      return { ...ex, tags: tags.join(', ') };
+    });
+    labels.value = labels.value.filter(l => l.name !== labelName);
+
+    expect(exercises.value[0].tags).toBe('Chest');
+    expect(exercises.value[1].tags).toBe('');
+    expect(labels.value).toHaveLength(0);
+  });
+});
+
+describe('AC4: Tap-to-toggle label chips', () => {
+  beforeEach(resetSignals);
+
+  it('toggling a label on adds it to exercise tags', () => {
+    const tags = ['Push'];
+    const newTag = 'Chest';
+    const updated = [...tags, newTag];
+    expect(updated).toEqual(['Push', 'Chest']);
+  });
+
+  it('toggling an active label off removes it from exercise tags', () => {
+    const tags = ['Push', 'Chest'];
+    const removeTag = 'Chest';
+    const updated = tags.filter(t => t !== removeTag);
+    expect(updated).toEqual(['Push']);
+  });
+
+  it('all labels are available in the chip grid', () => {
+    labels.value = [
+      makeLabel({ name: 'Push' }),
+      makeLabel({ name: 'Pull', id: 'lbl2', sheetRow: 3 }),
+      makeLabel({ name: 'Legs', id: 'lbl3', sheetRow: 4 }),
+    ];
+    expect(labels.value).toHaveLength(3);
+  });
+});
+
+describe('AC5: Label colors on tag badges', () => {
+  beforeEach(resetSignals);
+
+  it('getLabelByName returns the label with its color_key', () => {
+    labels.value = [
+      makeLabel({ name: 'Push', color_key: 'red' }),
+      makeLabel({ name: 'Pull', color_key: 'blue', id: 'lbl2', sheetRow: 3 }),
+    ];
+
+    const push = getLabelByName('Push');
+    expect(push).toBeDefined();
+    expect(push!.color_key).toBe('red');
+
+    const pull = getLabelByName('Pull');
+    expect(pull).toBeDefined();
+    expect(pull!.color_key).toBe('blue');
+  });
+
+  it('getLabelColor returns light and dark theme pairs', () => {
+    const red = getLabelColor('red');
+    expect(red).toBeDefined();
+    expect(red!.light.bg).toBeTruthy();
+    expect(red!.light.text).toBeTruthy();
+    expect(red!.dark.bg).toBeTruthy();
+    expect(red!.dark.text).toBeTruthy();
+  });
+
+  it('falls back gracefully for unknown label names', () => {
+    labels.value = [];
+    const result = getLabelByName('Nonexistent');
+    expect(result).toBeUndefined();
+  });
+
+  it('color swatch picker has 10 predefined colors', () => {
+    expect(LABEL_COLORS).toHaveLength(10);
+    // Each has a name for aria-label
+    for (const c of LABEL_COLORS) {
+      expect(c.name).toBeTruthy();
+    }
+  });
+});
+
+describe('Router: manage-labels route', () => {
+  it('parses /settings/labels as manage-labels route', async () => {
+    const { currentRoute } = await import('../../router/router');
+    window.location.hash = '/settings/labels';
+    window.dispatchEvent(new Event('hashchange'));
+    expect(currentRoute.value.name).toBe('manage-labels');
+  });
+});

--- a/frontend/src/components/settings/settings-screen.tsx
+++ b/frontend/src/components/settings/settings-screen.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '../../auth/auth-context';
 import { ThemeToggle } from '../shared/theme-toggle';
-import { workouts, exercises, templates } from '../../state/store';
+import { workouts, exercises, templates, labels } from '../../state/store';
+import { navigate } from '../../router/router';
 
 export function SettingsScreen() {
   const { user, logout } = useAuth();
@@ -32,6 +33,16 @@ export function SettingsScreen() {
           <div class="settings-row">
             <span>Templates</span>
             <span class="settings-detail">{templates.value.length} saved</span>
+          </div>
+          <div
+            class="settings-row settings-row-link"
+            onClick={() => navigate('/settings/labels')}
+            role="button"
+            tabIndex={0}
+            onKeyDown={e => { if (e.key === 'Enter') navigate('/settings/labels'); }}
+          >
+            <span>Labels</span>
+            <span class="settings-detail">{labels.value.length} defined &rsaquo;</span>
           </div>
         </div>
 

--- a/frontend/src/components/shared/bottom-nav.tsx
+++ b/frontend/src/components/shared/bottom-nav.tsx
@@ -15,7 +15,8 @@ export function BottomNav() {
       {tabs.map(tab => {
         const isActive = route.name === tab.name ||
           (tab.name === 'history' && ['workout-detail', 'workout-edit', 'workout-new', 'workout-active'].includes(route.name)) ||
-          (tab.name === 'templates' && ['template-new', 'template-edit'].includes(route.name));
+          (tab.name === 'templates' && ['template-new', 'template-edit'].includes(route.name)) ||
+          (tab.name === 'settings' && route.name === 'manage-labels');
         return (
           <button
             key={tab.name}

--- a/frontend/src/components/shared/color-swatch-picker.tsx
+++ b/frontend/src/components/shared/color-swatch-picker.tsx
@@ -1,0 +1,32 @@
+import { LABEL_COLORS } from '../../api/label-colors';
+
+interface ColorSwatchPickerProps {
+  selected: string;
+  onSelect: (colorKey: string) => void;
+}
+
+export function ColorSwatchPicker({ selected, onSelect }: ColorSwatchPickerProps) {
+  return (
+    <div class="color-swatch-grid" role="radiogroup" aria-label="Label color">
+      {LABEL_COLORS.map(color => {
+        const isSelected = selected === color.key;
+        return (
+          <button
+            key={color.key}
+            type="button"
+            class={`color-swatch${isSelected ? ' selected' : ''}`}
+            style={{ background: color.light.bg, color: color.light.text, borderColor: color.light.text }}
+            onClick={() => onSelect(color.key)}
+            aria-label={color.name}
+            role="radio"
+            aria-checked={isSelected}
+          >
+            {isSelected && (
+              <span class="color-swatch-check" aria-hidden="true">&#10003;</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/confirm-modal.tsx
+++ b/frontend/src/components/shared/confirm-modal.tsx
@@ -1,0 +1,50 @@
+interface ConfirmModalProps {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  title,
+  message,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  danger = true,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const handleBackgroundClick = (e: MouseEvent) => {
+    if ((e.target as HTMLElement).classList.contains('modal-overlay')) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div class="modal-overlay" onClick={handleBackgroundClick}>
+      <div class="modal-content" style="max-width: 360px;">
+        <h2 style="font-size: var(--text-lg); font-weight: 700; margin-bottom: var(--space-sm);">
+          {title}
+        </h2>
+        <p style="color: var(--color-text-secondary); margin-bottom: var(--space-lg);">
+          {message}
+        </p>
+        <div class="form-actions">
+          <button type="button" class="btn btn-secondary" onClick={onCancel}>
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            class={`btn ${danger ? 'btn-danger' : 'btn-primary'}`}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/label-badge.tsx
+++ b/frontend/src/components/shared/label-badge.tsx
@@ -1,0 +1,36 @@
+import { getLabelByName } from '../../state/store';
+import { getLabelColor } from '../../api/label-colors';
+
+interface LabelBadgeProps {
+  name: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+/** Renders a tag badge using the label's assigned color. Falls back to default primary styling. */
+export function LabelBadge({ name, active, onClick }: LabelBadgeProps) {
+  const label = getLabelByName(name);
+  const color = label ? getLabelColor(label.color_key) : undefined;
+
+  const style: Record<string, string> = {};
+  if (color) {
+    // We use CSS custom properties per-badge, consumed by the .tag-badge rule
+    style['--label-bg'] = color.light.bg;
+    style['--label-text'] = color.light.text;
+    style['--label-bg-dark'] = color.dark.bg;
+    style['--label-text-dark'] = color.dark.text;
+  }
+
+  const Tag = onClick ? 'button' : 'span';
+  const extraProps = onClick ? { type: 'button' as const, onClick } : {};
+
+  return (
+    <Tag
+      class={`tag-badge${color ? ' tag-badge-colored' : ''}${active ? ' active' : ''}`}
+      style={style}
+      {...extraProps}
+    >
+      {name}
+    </Tag>
+  );
+}

--- a/frontend/src/components/shared/label-chip-grid.tsx
+++ b/frontend/src/components/shared/label-chip-grid.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'preact/hooks';
+import { labels } from '../../state/store';
+import { addLabel } from '../../state/actions';
+import { useAuth } from '../../auth/auth-context';
+import { getLabelColor, LABEL_COLORS } from '../../api/label-colors';
+import { ColorSwatchPicker } from './color-swatch-picker';
+import { navigate } from '../../router/router';
+
+interface LabelChipGridProps {
+  selected: string[];
+  onToggle: (labelName: string) => void;
+  onCreated?: (labelName: string) => void;
+}
+
+export function LabelChipGrid({ selected, onToggle, onCreated }: LabelChipGridProps) {
+  const { token } = useAuth();
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newColor, setNewColor] = useState(LABEL_COLORS[0].key);
+  const [saving, setSaving] = useState(false);
+
+  const handleCreate = async () => {
+    if (!newName.trim() || !token || saving) return;
+    setSaving(true);
+    try {
+      const label = await addLabel({ name: newName.trim(), color_key: newColor }, token);
+      onToggle(label.name);
+      if (onCreated) onCreated(label.name);
+      setCreating(false);
+      setNewName('');
+      setNewColor(LABEL_COLORS[0].key);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="label-chip-grid-wrapper">
+      <div class="label-chip-grid">
+        {labels.value.map(label => {
+          const isActive = selected.includes(label.name);
+          const color = getLabelColor(label.color_key);
+          const style: Record<string, string> = {};
+          if (color) {
+            style['--label-bg'] = color.light.bg;
+            style['--label-text'] = color.light.text;
+            style['--label-bg-dark'] = color.dark.bg;
+            style['--label-text-dark'] = color.dark.text;
+          }
+          return (
+            <button
+              key={label.id}
+              type="button"
+              class={`label-chip${isActive ? ' label-chip-active' : ''}${color ? ' tag-badge-colored' : ''}`}
+              style={style}
+              onClick={() => onToggle(label.name)}
+              aria-pressed={isActive}
+            >
+              {label.name}
+            </button>
+          );
+        })}
+        {!creating && (
+          <button
+            type="button"
+            class="label-chip label-chip-create"
+            onClick={() => setCreating(true)}
+          >
+            + New Label
+          </button>
+        )}
+      </div>
+
+      {creating && (
+        <div class="label-create-inline">
+          <input
+            class="form-input"
+            type="text"
+            value={newName}
+            onInput={e => setNewName((e.target as HTMLInputElement).value)}
+            placeholder="Label name"
+            autoFocus
+            onKeyDown={e => {
+              if (e.key === 'Enter') { e.preventDefault(); handleCreate(); }
+              if (e.key === 'Escape') setCreating(false);
+            }}
+          />
+          <ColorSwatchPicker selected={newColor} onSelect={setNewColor} />
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary btn-sm" onClick={() => setCreating(false)}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              disabled={saving || !newName.trim()}
+              onClick={handleCreate}
+            >
+              {saving ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        class="manage-labels-link"
+        onClick={() => navigate('/settings/labels')}
+      >
+        Manage labels
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1766,3 +1766,257 @@ input, select, textarea {
   padding: var(--space-md) 0;
   border-bottom: 1px solid var(--color-border-light);
 }
+
+.settings-row-link {
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md) var(--space-sm);
+  margin: 0 calc(-1 * var(--space-sm));
+}
+
+.settings-row-link:hover {
+  background: var(--color-border-light);
+}
+
+/* ===== Colored Tag Badges ===== */
+.tag-badge-colored {
+  background: var(--label-bg, var(--color-primary-light));
+  color: var(--label-text, var(--color-primary));
+}
+
+[data-theme="dark"] .tag-badge-colored {
+  background: var(--label-bg-dark, var(--color-primary-light));
+  color: var(--label-text-dark, var(--color-primary));
+}
+
+.tag-badge-colored.active {
+  background: var(--label-text, var(--color-primary));
+  color: #fff;
+}
+
+[data-theme="dark"] .tag-badge-colored.active {
+  background: var(--label-text-dark, var(--color-primary));
+  color: #111;
+}
+
+/* ===== Color Swatch Picker ===== */
+.color-swatch-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  padding: var(--space-sm) 0;
+}
+
+.color-swatch {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  border: 2px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+  font-size: var(--text-base);
+  font-weight: 700;
+}
+
+.color-swatch:hover {
+  transform: scale(1.08);
+}
+
+.color-swatch.selected {
+  border-color: currentColor;
+}
+
+.color-swatch-check {
+  font-size: var(--text-lg);
+}
+
+/* ===== Label Chip Grid (Exercise Form) ===== */
+.label-chip-grid-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.label-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.label-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  border: 2px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.label-chip:hover {
+  border-color: var(--color-text-muted);
+}
+
+.label-chip.tag-badge-colored {
+  border-color: var(--label-text, var(--color-border));
+  background: transparent;
+  color: var(--label-text, var(--color-text-secondary));
+  opacity: 0.55;
+}
+
+[data-theme="dark"] .label-chip.tag-badge-colored {
+  border-color: var(--label-text-dark, var(--color-border));
+  color: var(--label-text-dark, var(--color-text-secondary));
+}
+
+.label-chip-active {
+  opacity: 1 !important;
+  border-color: transparent;
+}
+
+.label-chip-active.tag-badge-colored {
+  background: var(--label-bg, var(--color-primary-light));
+  color: var(--label-text, var(--color-primary));
+  border-color: var(--label-text, var(--color-primary));
+}
+
+[data-theme="dark"] .label-chip-active.tag-badge-colored {
+  background: var(--label-bg-dark, var(--color-primary-light));
+  color: var(--label-text-dark, var(--color-primary));
+  border-color: var(--label-text-dark, var(--color-primary));
+}
+
+.label-chip-create {
+  border-style: dashed;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  opacity: 0.6;
+}
+
+.label-chip-create:hover {
+  opacity: 1;
+}
+
+.label-create-inline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.manage-labels-link {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-align: left;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.manage-labels-link:hover {
+  color: var(--color-primary);
+}
+
+/* ===== Manage Labels Screen ===== */
+.manage-labels-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.manage-label-row {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.manage-label-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 44px;
+}
+
+.manage-label-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.manage-label-name {
+  flex: 1;
+  text-align: left;
+  font-weight: 600;
+  font-size: var(--text-base);
+  padding: var(--space-xs) 0;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.manage-label-name:hover {
+  color: var(--color-primary);
+}
+
+.manage-label-edit-input {
+  flex: 1;
+  min-height: 36px;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--text-base);
+}
+
+.manage-label-usage {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.manage-label-delete {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-lg);
+  color: var(--color-text-muted);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.manage-label-delete:hover {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.manage-label-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -38,6 +38,9 @@ function parseHash(hash: string): ParsedRoute {
   // /exercises
   if (path === '/exercises') return { name: 'exercises', params: {}, hash: path };
 
+  // /settings/labels
+  if (path === '/settings/labels') return { name: 'manage-labels', params: {}, hash: path };
+
   // /settings
   if (path === '/settings') return { name: 'settings', params: {}, hash: path };
 

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -14,4 +14,5 @@ export const routes: Route[] = [
   { pattern: '/templates/:id', name: 'template-edit' },
   { pattern: '/exercises', name: 'exercises' },
   { pattern: '/settings', name: 'settings' },
+  { pattern: '/settings/labels', name: 'manage-labels' },
 ];

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -1,9 +1,11 @@
-import { exercises, templates, workouts, sets, loading, activeWorkoutId, activeWorkoutSets, activeWarmupExercises, showToast } from './store';
+import { exercises, labels, templates, workouts, sets, loading, activeWorkoutId, activeWorkoutSets, activeWarmupExercises, showToast } from './store';
 import { fetchExercises, createExercise, updateExercise as updateExerciseApi, deleteExercise as deleteExerciseApi } from '../api/exercises-api';
+import { fetchLabels, createLabel as createLabelApi, updateLabel as updateLabelApi, deleteLabel as deleteLabelApi, appendLabels } from '../api/labels-api';
 import { fetchTemplateRows, groupTemplateRows, createTemplate as createTemplateApi, updateTemplate as updateTemplateApi, deleteTemplate as deleteTemplateApi } from '../api/templates-api';
 import { fetchWorkouts, fetchSets, createWorkout as createWorkoutApi, updateWorkout as updateWorkoutApi, deleteWorkoutRows, appendSet as appendSetApi, appendSets as appendSetsApi, updateSet as updateSetApi, deleteSetRow } from '../api/workouts-api';
+import { colorKeyFromName } from '../api/label-colors';
 import type { TemplateExerciseInput } from '../api/templates-api';
-import type { ExerciseWithRow, TemplateRowWithRow, WorkoutType, WorkoutSet, SetWithRow } from '../api/types';
+import type { ExerciseWithRow, LabelWithRow, TemplateRowWithRow, WorkoutType, WorkoutSet, SetWithRow } from '../api/types';
 import { ReauthFailedError } from '../auth/reauth';
 
 function isReauthFailure(err: unknown): boolean {
@@ -22,8 +24,9 @@ export function parseSetCount(setsStr: string): number {
 export async function loadInitialData(token: string): Promise<void> {
   loading.value = true;
   try {
-    const [exerciseData, templateRowData, workoutData, setData] = await Promise.all([
+    const [exerciseData, labelData, templateRowData, workoutData, setData] = await Promise.all([
       fetchExercises(token),
+      fetchLabels(token),
       fetchTemplateRows(token),
       fetchWorkouts(token),
       fetchSets(token),
@@ -32,6 +35,15 @@ export async function loadInitialData(token: string): Promise<void> {
     templates.value = groupTemplateRows(templateRowData);
     workouts.value = workoutData;
     sets.value = setData;
+
+    // Bootstrap labels: if Labels sheet is empty but exercises have tags, auto-create labels
+    if (labelData.length === 0 && exerciseData.length > 0) {
+      const bootstrapped = await bootstrapLabels(exerciseData, token);
+      labels.value = bootstrapped;
+    } else {
+      labels.value = labelData;
+    }
+
     loading.value = false;
   } catch (err) {
     if (isReauthFailure(err)) return; // auth-provider handles this
@@ -39,6 +51,34 @@ export async function loadInitialData(token: string): Promise<void> {
     showToast('Failed to load data', 'error');
     loading.value = false;
   }
+}
+
+/** One-time migration: create label rows for all unique tags found in exercises. */
+async function bootstrapLabels(
+  exerciseData: ExerciseWithRow[],
+  token: string,
+): Promise<LabelWithRow[]> {
+  const tagSet = new Set<string>();
+  for (const ex of exerciseData) {
+    if (ex.tags) {
+      ex.tags.split(',').map(t => t.trim()).filter(Boolean).forEach(t => tagSet.add(t));
+    }
+  }
+  if (tagSet.size === 0) return [];
+
+  const sorted = Array.from(tagSet).sort();
+  const now = new Date().toISOString();
+  const newLabels = sorted.map((name) => ({
+    id: `lbl_${crypto.randomUUID().slice(0, 8)}`,
+    name,
+    color_key: colorKeyFromName(name),
+    created: now,
+  }));
+
+  await appendLabels(newLabels, token);
+
+  // Return with approximate sheetRow values
+  return newLabels.map((l, i) => ({ ...l, sheetRow: i + 2 }));
 }
 
 // ── Templates ────────────────────────────────────────────────────────
@@ -509,6 +549,114 @@ export async function startSimpleWorkout(
   } catch (err) {
     if (isReauthFailure(err)) throw err;
     showToast('Failed to save workout', 'error');
+    throw err;
+  }
+}
+
+// ── Labels ──────────────────────────────────────────────────────────
+
+export async function addLabel(
+  data: { name: string; color_key: string },
+  token: string,
+): Promise<LabelWithRow> {
+  try {
+    const created = await createLabelApi(data, token);
+    const withRow: LabelWithRow = {
+      ...created,
+      sheetRow: labels.value.length + 2,
+    };
+    labels.value = [...labels.value, withRow];
+    showToast('Label created', 'success');
+    return withRow;
+  } catch (err) {
+    if (isReauthFailure(err)) throw err;
+    showToast('Failed to create label', 'error');
+    throw err;
+  }
+}
+
+export async function renameLabel(
+  label: LabelWithRow,
+  newName: string,
+  token: string,
+): Promise<void> {
+  try {
+    const oldName = label.name;
+
+    // Update all exercises that have this tag
+    const affected = exercises.value.filter(ex =>
+      ex.tags.split(',').map(t => t.trim()).filter(Boolean).includes(oldName),
+    );
+
+    for (const ex of affected) {
+      const tags = ex.tags.split(',').map(t => t.trim()).filter(Boolean);
+      const updated = tags.map(t => t === oldName ? newName : t).join(', ');
+      const updatedEx: ExerciseWithRow = { ...ex, tags: updated };
+      await updateExerciseApi(ex.sheetRow, updatedEx, token);
+      exercises.value = exercises.value.map(e => e.id === ex.id ? updatedEx : e);
+    }
+
+    // Update the label itself
+    const updatedLabel: LabelWithRow = { ...label, name: newName };
+    await updateLabelApi(label.sheetRow, updatedLabel, token);
+    labels.value = labels.value.map(l => l.id === label.id ? updatedLabel : l);
+
+    showToast(`Renamed '${oldName}' to '${newName}' across ${affected.length} exercises`, 'success');
+  } catch (err) {
+    if (isReauthFailure(err)) throw err;
+    showToast('Failed to rename label', 'error');
+    throw err;
+  }
+}
+
+export async function updateLabelColor(
+  label: LabelWithRow,
+  newColorKey: string,
+  token: string,
+): Promise<void> {
+  try {
+    const updatedLabel: LabelWithRow = { ...label, color_key: newColorKey };
+    await updateLabelApi(label.sheetRow, updatedLabel, token);
+    labels.value = labels.value.map(l => l.id === label.id ? updatedLabel : l);
+  } catch (err) {
+    if (isReauthFailure(err)) throw err;
+    showToast('Failed to update label color', 'error');
+    throw err;
+  }
+}
+
+export async function removeLabel(
+  label: LabelWithRow,
+  token: string,
+): Promise<number> {
+  try {
+    const labelName = label.name;
+
+    // Remove from all exercises that have this tag
+    const affected = exercises.value.filter(ex =>
+      ex.tags.split(',').map(t => t.trim()).filter(Boolean).includes(labelName),
+    );
+
+    for (const ex of affected) {
+      const tags = ex.tags.split(',').map(t => t.trim()).filter(Boolean);
+      const updated = tags.filter(t => t !== labelName).join(', ');
+      const updatedEx: ExerciseWithRow = { ...ex, tags: updated };
+      await updateExerciseApi(ex.sheetRow, updatedEx, token);
+      exercises.value = exercises.value.map(e => e.id === ex.id ? updatedEx : e);
+    }
+
+    // Delete the label row
+    await deleteLabelApi(label.sheetRow, token);
+
+    // Re-fetch labels to get correct sheetRow values after row shift
+    const fresh = await fetchLabels(token);
+    labels.value = fresh;
+
+    showToast(`Deleted '${labelName}' from ${affected.length} exercises`, 'success');
+    return affected.length;
+  } catch (err) {
+    if (isReauthFailure(err)) throw err;
+    showToast('Failed to delete label', 'error');
     throw err;
   }
 }

--- a/frontend/src/state/store.test.ts
+++ b/frontend/src/state/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   exercises,
+  labels,
   templates,
   workouts,
   sets,
@@ -8,14 +9,17 @@ import {
   filterTags,
   filteredWorkouts,
   allTags,
+  getLabelByName,
+  labelUsageCount,
   showToast,
   toasts,
 } from './store';
-import type { ExerciseWithRow, WorkoutWithRow, SetWithRow } from '../api/types';
+import type { ExerciseWithRow, LabelWithRow, WorkoutWithRow, SetWithRow } from '../api/types';
 
 // Helper to reset all signals to defaults between tests
 function resetSignals() {
   exercises.value = [];
+  labels.value = [];
   templates.value = [];
   workouts.value = [];
   sets.value = [];
@@ -47,6 +51,17 @@ function makeExercise(overrides: Partial<ExerciseWithRow> = {}): ExerciseWithRow
     name: 'Bench Press',
     tags: 'Push, Chest',
     notes: '',
+    created: '2025-01-01T00:00:00.000Z',
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+function makeLabel(overrides: Partial<LabelWithRow> = {}): LabelWithRow {
+  return {
+    id: 'lbl1',
+    name: 'Push',
+    color_key: 'red',
     created: '2025-01-01T00:00:00.000Z',
     sheetRow: 2,
     ...overrides,
@@ -215,38 +230,57 @@ describe('filteredWorkouts', () => {
   });
 });
 
-describe('allTags', () => {
+describe('allTags (sourced from labels signal)', () => {
   beforeEach(resetSignals);
 
-  it('returns empty array when no exercises exist', () => {
+  it('returns empty array when no labels exist', () => {
     expect(allTags.value).toEqual([]);
   });
 
-  it('extracts unique tags from exercises and sorts them', () => {
-    exercises.value = [
-      makeExercise({ id: 'ex1', tags: 'Push, Chest, Compound' }),
-      makeExercise({ id: 'ex2', tags: 'Pull, Back, Compound' }),
-      makeExercise({ id: 'ex3', tags: 'Legs' }),
+  it('returns sorted label names', () => {
+    labels.value = [
+      makeLabel({ id: 'lbl1', name: 'Push' }),
+      makeLabel({ id: 'lbl2', name: 'Chest' }),
+      makeLabel({ id: 'lbl3', name: 'Arms' }),
     ];
 
-    expect(allTags.value).toEqual(['Back', 'Chest', 'Compound', 'Legs', 'Pull', 'Push']);
+    expect(allTags.value).toEqual(['Arms', 'Chest', 'Push']);
+  });
+});
+
+describe('getLabelByName', () => {
+  beforeEach(resetSignals);
+
+  it('finds a label by name', () => {
+    labels.value = [
+      makeLabel({ id: 'lbl1', name: 'Push', color_key: 'red' }),
+      makeLabel({ id: 'lbl2', name: 'Pull', color_key: 'blue' }),
+    ];
+
+    const result = getLabelByName('Pull');
+    expect(result).toBeDefined();
+    expect(result!.color_key).toBe('blue');
   });
 
-  it('handles exercises with no tags', () => {
-    exercises.value = [
-      makeExercise({ id: 'ex1', tags: '' }),
-      makeExercise({ id: 'ex2', tags: 'Push' }),
-    ];
-
-    expect(allTags.value).toEqual(['Push']);
+  it('returns undefined for non-existent label', () => {
+    labels.value = [makeLabel({ name: 'Push' })];
+    expect(getLabelByName('Nonexistent')).toBeUndefined();
   });
+});
 
-  it('trims whitespace from tags', () => {
+describe('labelUsageCount', () => {
+  beforeEach(resetSignals);
+
+  it('counts exercises that use a given label', () => {
     exercises.value = [
-      makeExercise({ id: 'ex1', tags: ' Push , Chest ' }),
+      makeExercise({ id: 'ex1', tags: 'Push, Chest' }),
+      makeExercise({ id: 'ex2', tags: 'Push, Shoulders' }),
+      makeExercise({ id: 'ex3', tags: 'Pull, Back' }),
     ];
 
-    expect(allTags.value).toEqual(['Chest', 'Push']);
+    expect(labelUsageCount('Push')).toBe(2);
+    expect(labelUsageCount('Pull')).toBe(1);
+    expect(labelUsageCount('Core')).toBe(0);
   });
 });
 

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -1,8 +1,9 @@
 import { signal, computed } from '@preact/signals';
-import type { ExerciseWithRow, Template, WorkoutWithRow, SetWithRow, WorkoutType } from '../api/types';
+import type { ExerciseWithRow, LabelWithRow, Template, WorkoutWithRow, SetWithRow, WorkoutType } from '../api/types';
 
 // Core data signals
 export const exercises = signal<ExerciseWithRow[]>([]);
+export const labels = signal<LabelWithRow[]>([]);
 export const templates = signal<Template[]>([]);
 export const workouts = signal<WorkoutWithRow[]>([]);
 export const sets = signal<SetWithRow[]>([]);
@@ -50,15 +51,22 @@ export const filteredWorkouts = computed(() => {
   });
 });
 
+// allTags: sourced from labels signal (backwards compat for filter rows)
 export const allTags = computed(() => {
-  const tagSet = new Set<string>();
-  for (const ex of exercises.value) {
-    if (ex.tags) {
-      ex.tags.split(',').map(t => t.trim()).filter(Boolean).forEach(t => tagSet.add(t));
-    }
-  }
-  return Array.from(tagSet).sort();
+  return labels.value.map(l => l.name).sort();
 });
+
+/** Look up a label by name. */
+export function getLabelByName(name: string): LabelWithRow | undefined {
+  return labels.value.find(l => l.name === name);
+}
+
+/** Count how many exercises use a given label name. */
+export function labelUsageCount(labelName: string): number {
+  return exercises.value.filter(ex =>
+    ex.tags.split(',').map(t => t.trim()).filter(Boolean).includes(labelName),
+  ).length;
+}
 
 // Toast system
 export interface ToastMessage {


### PR DESCRIPTION
Closes #7

## Changes

- **New Labels sheet tab** (`id`, `name`, `color_key`, `created`) — source of truth for label metadata
- **Auto-migration**: On first load, existing exercise tags are bootstrapped into Labels rows with deterministic color assignment
- **Manage Labels screen** (Settings > Data > Labels): create, rename, delete labels with color swatch picker
- **Color system**: 10 predefined colors with light + dark theme pairs, matching section badge pattern
- **Exercise form**: Type-and-suggest replaced with tap-to-toggle label chip grid; inline `+ New Label` creation; "Manage labels" link
- **Label colors everywhere**: Tag badges in Exercise Library, Add Exercise Modal, and History Filters use per-label colors
- **Confirm modal**: In-app deletion confirmation with exercise count (not `window.confirm`)
- **Propagation**: Rename and delete operations update all affected exercises with toast feedback

### New files
- `label-colors.ts` — LABEL_COLORS palette constant + helpers
- `labels-api.ts` — Sheets CRUD for Labels tab
- `confirm-modal.tsx`, `color-swatch-picker.tsx`, `label-badge.tsx`, `label-chip-grid.tsx` — shared components
- `manage-labels-screen.tsx` — Manage Labels page

### Test coverage
- 100 tests passing (10 test files)
- New test files: `label-colors.test.ts`, `manage-labels.test.ts`
- Updated: `store.test.ts`, `exercises-screen.test.ts`