### PR TITLE
feat: quick-fill reps alongside weight (#16)

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -10,6 +10,7 @@ export interface TrackerExercise {
   exercise_order: number;
   sets: TrackerSet[];
   quickFillWeight: string;
+  quickFillReps: string;
 }
 
 interface Props {
@@ -19,6 +20,7 @@ interface Props {
   onAddSet: () => void;
   onRemoveSet: (setNumber: number) => void;
   onQuickFillWeight: (weight: string) => void;
+  onQuickFillReps: (reps: string) => void;
 }
 
 function sectionBadgeClass(section: string): string {
@@ -26,7 +28,7 @@ function sectionBadgeClass(section: string): string {
   return `section-badge section-${section}`;
 }
 
-export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet, onRemoveSet, onQuickFillWeight }: Props) {
+export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet, onRemoveSet, onQuickFillWeight, onQuickFillReps }: Props) {
   const isWarmup = exercise.section === 'warmup';
   const [showLastTime, setShowLastTime] = useState(false);
 
@@ -88,15 +90,27 @@ export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet,
       )}
 
       <div class="quick-fill-row">
-        <label class="quick-fill-label" for={`quick-fill-${exercise.exercise_id}-${exercise.exercise_order}`}>Weight</label>
+        <span class="quick-fill-label">Quick fill</span>
         <input
-          id={`quick-fill-${exercise.exercise_id}-${exercise.exercise_order}`}
+          id={`quick-fill-wt-${exercise.exercise_id}-${exercise.exercise_order}`}
           class="form-input quick-fill-input"
           type="number"
           inputMode="decimal"
-          placeholder="Fill all sets (lbs)"
+          placeholder="lbs"
+          aria-label="Fill all sets weight (lbs)"
           value={exercise.quickFillWeight}
           onInput={(e) => onQuickFillWeight((e.target as HTMLInputElement).value)}
+        />
+        <span class="set-input-separator">×</span>
+        <input
+          id={`quick-fill-reps-${exercise.exercise_id}-${exercise.exercise_order}`}
+          class="form-input quick-fill-input"
+          type="number"
+          inputMode="numeric"
+          placeholder="reps"
+          aria-label="Fill all sets reps"
+          value={exercise.quickFillReps}
+          onInput={(e) => onQuickFillReps((e.target as HTMLInputElement).value)}
         />
       </div>
 

--- a/frontend/src/components/workout/quick-fill.test.ts
+++ b/frontend/src/components/workout/quick-fill.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyQuickFillWeight } from './quick-fill';
+import { applyQuickFillWeight, applyQuickFillReps } from './quick-fill';
 import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
 
@@ -25,6 +25,7 @@ function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise
     exercise_order: 1,
     sets: [makeSet({ set_number: 1 }), makeSet({ set_number: 2 }), makeSet({ set_number: 3 })],
     quickFillWeight: '',
+    quickFillReps: '',
     ...overrides,
   };
 }
@@ -117,5 +118,116 @@ describe('applyQuickFillWeight', () => {
     expect(result[0].sets[0].weight).toBe('155');
     expect(result[0].sets[1].weight).toBe('155');
     expect(result[0].sets[2].weight).toBe('155');
+  });
+});
+
+describe('applyQuickFillReps', () => {
+  // AC1: Reps quick-fill applies rep count to all sets
+  it('fills all sets with reps value and marks unsaved', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, reps: '' }),
+        makeSet({ set_number: 2, reps: '' }),
+        makeSet({ set_number: 3, reps: '' }),
+      ],
+    })];
+
+    const result = applyQuickFillReps(exercises, 'ex1', 1, '10');
+
+    expect(result[0].quickFillReps).toBe('10');
+    expect(result[0].sets[0].reps).toBe('10');
+    expect(result[0].sets[1].reps).toBe('10');
+    expect(result[0].sets[2].reps).toBe('10');
+    expect(result[0].sets[0].saved).toBe(false);
+    expect(result[0].sets[1].saved).toBe(false);
+    expect(result[0].sets[2].saved).toBe(false);
+  });
+
+  // AC2: Lbs and reps quick-fill work independently — reps does not touch weight
+  it('does not modify weight values when filling reps', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, weight: '135', reps: '8', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, weight: '135', reps: '6', saved: true, sheetRow: 3 }),
+      ],
+    })];
+
+    const result = applyQuickFillReps(exercises, 'ex1', 1, '10');
+
+    // Weight should be untouched
+    expect(result[0].sets[0].weight).toBe('135');
+    expect(result[0].sets[1].weight).toBe('135');
+    // Reps should be overwritten
+    expect(result[0].sets[0].reps).toBe('10');
+    expect(result[0].sets[1].reps).toBe('10');
+  });
+
+  // AC2: Weight quick-fill does not touch reps
+  it('weight quick-fill does not modify reps values', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, weight: '', reps: '10' }),
+        makeSet({ set_number: 2, weight: '', reps: '8' }),
+      ],
+    })];
+
+    const result = applyQuickFillWeight(exercises, 'ex1', 1, '185');
+
+    expect(result[0].sets[0].weight).toBe('185');
+    expect(result[0].sets[1].weight).toBe('185');
+    // Reps untouched
+    expect(result[0].sets[0].reps).toBe('10');
+    expect(result[0].sets[1].reps).toBe('8');
+  });
+
+  // AC3: Clearing reps quick-fill does not wipe individual set reps
+  it('does not clear existing set reps when quick fill is cleared', () => {
+    const exercises = [makeExercise({
+      quickFillReps: '10',
+      sets: [
+        makeSet({ set_number: 1, reps: '10', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, reps: '10', saved: true, sheetRow: 3 }),
+      ],
+    })];
+
+    const result = applyQuickFillReps(exercises, 'ex1', 1, '');
+
+    expect(result[0].quickFillReps).toBe('');
+    // Set reps should NOT be cleared
+    expect(result[0].sets[0].reps).toBe('10');
+    expect(result[0].sets[1].reps).toBe('10');
+    // Saved status should be preserved
+    expect(result[0].sets[0].saved).toBe(true);
+    expect(result[0].sets[1].saved).toBe(true);
+  });
+
+  it('only affects the matching exercise', () => {
+    const exercises = [
+      makeExercise({ exercise_id: 'ex1', exercise_order: 1 }),
+      makeExercise({ exercise_id: 'ex2', exercise_order: 2, exercise_name: 'Squat' }),
+    ];
+
+    const result = applyQuickFillReps(exercises, 'ex1', 1, '12');
+
+    expect(result[0].sets[0].reps).toBe('12');
+    // Second exercise untouched
+    expect(result[1].sets[0].reps).toBe('');
+    expect(result[1].quickFillReps).toBe('');
+  });
+
+  it('overwrites pre-filled reps with new value', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, reps: '8', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, reps: '6', saved: true, sheetRow: 3 }),
+      ],
+    })];
+
+    const result = applyQuickFillReps(exercises, 'ex1', 1, '10');
+
+    expect(result[0].sets[0].reps).toBe('10');
+    expect(result[0].sets[1].reps).toBe('10');
+    expect(result[0].sets[0].saved).toBe(false);
+    expect(result[0].sets[1].saved).toBe(false);
   });
 });

--- a/frontend/src/components/workout/quick-fill.ts
+++ b/frontend/src/components/workout/quick-fill.ts
@@ -23,3 +23,27 @@ export function applyQuickFillWeight(
     };
   });
 }
+
+/**
+ * Apply quick-fill reps to all sets for a matching exercise.
+ * When reps is non-empty, overwrites all set reps.
+ * When reps is empty, only updates the quickFillReps field (preserves existing set reps).
+ */
+export function applyQuickFillReps(
+  exercises: TrackerExercise[],
+  exerciseId: string,
+  exerciseOrder: number,
+  reps: string,
+): TrackerExercise[] {
+  return exercises.map((ex) => {
+    if (ex.exercise_id !== exerciseId || ex.exercise_order !== exerciseOrder) return ex;
+    return {
+      ...ex,
+      quickFillReps: reps,
+      sets: ex.sets.map((s) => {
+        if (!reps) return s;
+        return { ...s, reps, saved: false };
+      }),
+    };
+  });
+}

--- a/frontend/src/components/workout/warmup.test.ts
+++ b/frontend/src/components/workout/warmup.test.ts
@@ -25,6 +25,7 @@ function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise
     exercise_order: 1,
     sets: [],
     quickFillWeight: '',
+    quickFillReps: '',
     ...overrides,
   };
 }

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -8,7 +8,7 @@ import { ExerciseRow } from './exercise-row';
 import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
 import type { ExerciseWithRow, Effort } from '../../api/types';
-import { applyQuickFillWeight } from './quick-fill';
+import { applyQuickFillWeight, applyQuickFillReps } from './quick-fill';
 import { isWarmupExercise } from './warmup';
 
 interface Props {
@@ -32,6 +32,7 @@ function buildExerciseList(setRows: typeof activeWorkoutSets.value): TrackerExer
         exercise_order: s.exercise_order,
         sets: [],
         quickFillWeight: '',
+        quickFillReps: '',
       };
       map.set(key, ex);
     }
@@ -74,6 +75,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
       exercise_order: w.exercise_order,
       sets: [],
       quickFillWeight: '',
+      quickFillReps: '',
     }));
     const merged = [...warmups, ...tracked].sort((a, b) => a.exercise_order - b.exercise_order);
     setExerciseList(merged);
@@ -185,6 +187,23 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
     });
   };
 
+  const handleQuickFillReps = (exerciseId: string, exerciseOrder: number, reps: string) => {
+    setExerciseList((prev) => {
+      const next = applyQuickFillReps(prev, exerciseId, exerciseOrder, reps);
+      if (reps) {
+        const ex = next.find((e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder);
+        if (ex) {
+          for (const s of ex.sets) {
+            if (s.weight) {
+              setTimeout(() => debouncedSave(exerciseOrder, exerciseId, s), 0);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
   const handleAddSet = (exerciseId: string, exerciseOrder: number) => {
     setExerciseList((prev) =>
       prev.map((ex) => {
@@ -260,6 +279,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
         sheetRow: -1,
       }],
       quickFillWeight: '',
+      quickFillReps: '',
     };
     setExerciseList((prev) => [...prev, newExercise]);
     setShowExercisePicker(false);
@@ -395,6 +415,9 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
             }
             onQuickFillWeight={(weight) =>
               handleQuickFillWeight(ex.exercise_id, ex.exercise_order, weight)
+            }
+            onQuickFillReps={(reps) =>
+              handleQuickFillReps(ex.exercise_id, ex.exercise_order, reps)
             }
           />
         ))}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1223,6 +1223,7 @@ input, select, textarea {
 
 .quick-fill-input {
   flex: 1;
+  min-width: 64px;
   min-height: 44px;
   padding: var(--space-xs) var(--space-sm);
   font-size: var(--text-sm);


### PR DESCRIPTION
Closes #16

## Changes
- Added `applyQuickFillReps` function in `quick-fill.ts` mirroring existing weight logic
- Added `quickFillReps` field to `TrackerExercise` interface
- Updated quick-fill row UI: label changed to "Quick fill", two side-by-side inputs with `×` separator
- Both inputs have `aria-label` attributes for screen readers
- Added `min-width: 64px` to `.quick-fill-input` for thumb-friendly sizing at 375px
- Added `handleQuickFillReps` in workout tracker with auto-save wiring
- 6 new tests for reps quick-fill covering all ACs, existing tests updated

## Test plan
- [x] All 116 tests pass
- [x] TypeScript compiles clean
- [x] Production build succeeds