### PR TITLE
feat: section picker, reorder, and remove in workout tracker

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { SetRow } from './set-row';
 import { LastTimePanel } from './last-time-panel';
+import { ALL_SECTIONS } from './section-management';
 import type { TrackerSet } from './set-row';
 import type { SetWithRow } from '../../api/types';
 
@@ -23,6 +24,13 @@ interface Props {
   onQuickFillWeight: (weight: string) => void;
   onQuickFillReps: (reps: string) => void;
   onCopyDown: (lastTimeSets: SetWithRow[]) => void;
+  onChangeSection: (newSection: string) => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemoveExercise: () => void;
+  isFirst: boolean;
+  isLast: boolean;
+  totalExercises: number;
 }
 
 function sectionBadgeClass(section: string): string {
@@ -30,12 +38,50 @@ function sectionBadgeClass(section: string): string {
   return `section-badge section-${section}`;
 }
 
-export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet, onRemoveSet, onQuickFillWeight, onQuickFillReps, onCopyDown }: Props) {
+function sectionPillClass(section: string, active: boolean): string {
+  const base = 'section-picker-pill';
+  if (!active) return base;
+  if (section.startsWith('SS')) return `${base} section-picker-pill-active section-ss`;
+  return `${base} section-picker-pill-active section-${section}`;
+}
+
+export function ExerciseRow({
+  exercise,
+  currentWorkoutId,
+  onUpdateSet,
+  onAddSet,
+  onRemoveSet,
+  onQuickFillWeight,
+  onQuickFillReps,
+  onCopyDown,
+  onChangeSection,
+  onMoveUp,
+  onMoveDown,
+  onRemoveExercise,
+  isFirst,
+  isLast,
+  totalExercises,
+}: Props) {
   const isWarmup = exercise.section === 'warmup';
   const [showLastTime, setShowLastTime] = useState(false);
   const [flashSets, setFlashSets] = useState(false);
+  const [showSectionPicker, setShowSectionPicker] = useState(false);
+  const [showWarmupConfirm, setShowWarmupConfirm] = useState(false);
 
-  // AC4: Escape key closes the panel
+  // Escape closes section picker / warmup confirm
+  useEffect(() => {
+    if (!showSectionPicker && !showWarmupConfirm) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowSectionPicker(false);
+        setShowWarmupConfirm(false);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [showSectionPicker, showWarmupConfirm]);
+
+  // Escape key closes the last-time panel
   useEffect(() => {
     if (!showLastTime) return;
     const handler = (e: KeyboardEvent) => {
@@ -45,6 +91,111 @@ export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet,
     return () => document.removeEventListener('keydown', handler);
   }, [showLastTime]);
 
+  const handleSectionBadgeClick = () => {
+    if (showSectionPicker) {
+      setShowSectionPicker(false);
+      setShowWarmupConfirm(false);
+    } else {
+      setShowSectionPicker(true);
+      setShowWarmupConfirm(false);
+    }
+  };
+
+  const handlePillClick = (section: string) => {
+    if (section === exercise.section) {
+      // Already selected — collapse picker
+      setShowSectionPicker(false);
+      return;
+    }
+    if (section === 'warmup' && !isWarmup) {
+      // Show warmup confirmation
+      setShowWarmupConfirm(true);
+      setShowSectionPicker(false);
+      return;
+    }
+    onChangeSection(section);
+    setShowSectionPicker(false);
+    setShowWarmupConfirm(false);
+  };
+
+  const handleConfirmWarmup = () => {
+    onChangeSection('warmup');
+    setShowWarmupConfirm(false);
+  };
+
+  const showToolbar = totalExercises > 1;
+
+  const sectionPickerRow = showSectionPicker && (
+    <div class="section-picker-row" role="group" aria-label="Select section">
+      {ALL_SECTIONS.map((s) => (
+        <button
+          key={s}
+          type="button"
+          class={sectionPillClass(s, s === exercise.section)}
+          onClick={() => handlePillClick(s)}
+          aria-pressed={s === exercise.section ? 'true' : 'false'}
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+
+  const warmupConfirmRow = showWarmupConfirm && (
+    <div class="warmup-confirm-row">
+      <p class="warmup-confirm-text">
+        Warmup exercises are list-only — set data will be removed.
+      </p>
+      <div class="warmup-confirm-actions">
+        <button
+          type="button"
+          class="btn btn-danger"
+          onClick={handleConfirmWarmup}
+        >
+          Switch to Warmup
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          onClick={() => setShowWarmupConfirm(false)}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+
+  const toolbarRow = showToolbar && (
+    <div class="exercise-toolbar-row">
+      <button
+        type="button"
+        class="exercise-toolbar-btn"
+        onClick={onMoveUp}
+        disabled={isFirst}
+        aria-label={`Move ${exercise.exercise_name} up`}
+      >
+        ▲
+      </button>
+      <button
+        type="button"
+        class="exercise-toolbar-btn"
+        onClick={onMoveDown}
+        disabled={isLast}
+        aria-label={`Move ${exercise.exercise_name} down`}
+      >
+        ▼
+      </button>
+      <button
+        type="button"
+        class="exercise-toolbar-btn exercise-toolbar-remove"
+        onClick={onRemoveExercise}
+        aria-label={`Remove ${exercise.exercise_name}`}
+      >
+        ✕
+      </button>
+    </div>
+  );
+
   // Warmup exercises render as simplified name-only cards
   if (isWarmup) {
     return (
@@ -53,11 +204,20 @@ export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet,
         aria-label={`Warmup: ${exercise.exercise_name} (list only)`}
       >
         <div class="tracker-exercise-header">
-          <span class={sectionBadgeClass(exercise.section)}>
+          <button
+            type="button"
+            class={`${sectionBadgeClass(exercise.section)} section-badge-btn`}
+            onClick={handleSectionBadgeClick}
+            aria-label={`Change section (current: ${exercise.section})`}
+            aria-expanded={showSectionPicker ? 'true' : 'false'}
+          >
             {exercise.section}
-          </span>
+          </button>
           <span class="tracker-exercise-name">{exercise.exercise_name}</span>
         </div>
+        {sectionPickerRow}
+        {warmupConfirmRow}
+        {toolbarRow}
       </div>
     );
   }
@@ -68,9 +228,15 @@ export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet,
   return (
     <div class={cardClass}>
       <div class="tracker-exercise-header">
-        <span class={sectionBadgeClass(exercise.section)}>
+        <button
+          type="button"
+          class={`${sectionBadgeClass(exercise.section)} section-badge-btn`}
+          onClick={handleSectionBadgeClick}
+          aria-label={`Change section (current: ${exercise.section})`}
+          aria-expanded={showSectionPicker ? 'true' : 'false'}
+        >
           {exercise.section}
-        </span>
+        </button>
         <span class="tracker-exercise-name">{exercise.exercise_name}</span>
         <button
           class="last-time-toggle"
@@ -84,6 +250,10 @@ export function ExerciseRow({ exercise, currentWorkoutId, onUpdateSet, onAddSet,
           </svg>
         </button>
       </div>
+
+      {sectionPickerRow}
+      {warmupConfirmRow}
+      {toolbarRow}
 
       {showLastTime && (
         <LastTimePanel

--- a/frontend/src/components/workout/section-management.test.ts
+++ b/frontend/src/components/workout/section-management.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { applyChangeSection, applyMoveUp, applyMoveDown, ALL_SECTIONS } from './section-management';
+import type { TrackerExercise } from './exercise-row';
+import type { TrackerSet } from './set-row';
+
+function makeSet(overrides: Partial<TrackerSet> = {}): TrackerSet {
+  return {
+    set_number: 1,
+    planned_reps: '',
+    weight: '135',
+    reps: '8',
+    effort: 'Medium',
+    notes: '',
+    saved: true,
+    sheetRow: 10,
+    ...overrides,
+  };
+}
+
+function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise {
+  return {
+    exercise_id: 'ex1',
+    exercise_name: 'Bench Press',
+    section: 'primary',
+    exercise_order: 1,
+    sets: [makeSet({ set_number: 1 }), makeSet({ set_number: 2 })],
+    quickFillWeight: '',
+    quickFillReps: '',
+    ...overrides,
+  };
+}
+
+describe('ALL_SECTIONS', () => {
+  it('contains all 7 expected section names', () => {
+    expect(ALL_SECTIONS).toHaveLength(7);
+    expect(ALL_SECTIONS).toContain('warmup');
+    expect(ALL_SECTIONS).toContain('primary');
+    expect(ALL_SECTIONS).toContain('SS1');
+    expect(ALL_SECTIONS).toContain('SS2');
+    expect(ALL_SECTIONS).toContain('SS3');
+    expect(ALL_SECTIONS).toContain('burnout');
+    expect(ALL_SECTIONS).toContain('cooldown');
+  });
+});
+
+describe('applyChangeSection', () => {
+  describe('AC1: non-warmup to non-warmup section change', () => {
+    it('updates section without touching sets', () => {
+      const exercises = [makeExercise({ section: 'primary' })];
+      const { exercises: result, removedSets } = applyChangeSection(exercises, 'ex1', 1, 'SS1');
+
+      expect(result[0].section).toBe('SS1');
+      expect(result[0].sets).toHaveLength(2);
+      expect(removedSets).toHaveLength(0);
+    });
+
+    it('preserves set data when changing between non-warmup sections', () => {
+      const exercises = [makeExercise({ section: 'burnout' })];
+      const { exercises: result } = applyChangeSection(exercises, 'ex1', 1, 'cooldown');
+
+      expect(result[0].section).toBe('cooldown');
+      expect(result[0].sets[0].weight).toBe('135');
+      expect(result[0].sets[0].reps).toBe('8');
+    });
+
+    it('does not affect other exercises', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1, section: 'primary' }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2, section: 'primary', exercise_name: 'Squat' }),
+      ];
+      const { exercises: result } = applyChangeSection(exercises, 'ex1', 1, 'SS2');
+
+      expect(result[0].section).toBe('SS2');
+      expect(result[1].section).toBe('primary');
+    });
+  });
+
+  describe('AC2: switching to warmup clears sets', () => {
+    it('removes all sets and returns them as removedSets', () => {
+      const sets = [
+        makeSet({ set_number: 1, sheetRow: 10 }),
+        makeSet({ set_number: 2, sheetRow: 11 }),
+        makeSet({ set_number: 3, sheetRow: 12 }),
+      ];
+      const exercises = [makeExercise({ sets })];
+      const { exercises: result, removedSets } = applyChangeSection(exercises, 'ex1', 1, 'warmup');
+
+      expect(result[0].section).toBe('warmup');
+      expect(result[0].sets).toHaveLength(0);
+      expect(removedSets).toHaveLength(3);
+      expect(removedSets[0].sheetRow).toBe(10);
+      expect(removedSets[2].sheetRow).toBe(12);
+    });
+
+    it('returns zero removedSets when exercise had no sets', () => {
+      const exercises = [makeExercise({ sets: [] })];
+      const { removedSets } = applyChangeSection(exercises, 'ex1', 1, 'warmup');
+
+      expect(removedSets).toHaveLength(0);
+    });
+  });
+
+  describe('AC2: switching from warmup to non-warmup adds single empty set', () => {
+    it('adds one empty set when converting from warmup', () => {
+      const exercises = [makeExercise({ section: 'warmup', sets: [] })];
+      const { exercises: result, removedSets } = applyChangeSection(exercises, 'ex1', 1, 'primary');
+
+      expect(result[0].section).toBe('primary');
+      expect(result[0].sets).toHaveLength(1);
+      expect(result[0].sets[0].set_number).toBe(1);
+      expect(result[0].sets[0].weight).toBe('');
+      expect(result[0].sets[0].reps).toBe('');
+      expect(result[0].sets[0].saved).toBe(false);
+      expect(result[0].sets[0].sheetRow).toBe(-1);
+      expect(removedSets).toHaveLength(0);
+    });
+
+    it('works for all non-warmup target sections', () => {
+      const nonWarmup = ['primary', 'SS1', 'SS2', 'SS3', 'burnout', 'cooldown'];
+      for (const section of nonWarmup) {
+        const exercises = [makeExercise({ section: 'warmup', sets: [] })];
+        const { exercises: result } = applyChangeSection(exercises, 'ex1', 1, section);
+        expect(result[0].section).toBe(section);
+        expect(result[0].sets).toHaveLength(1);
+      }
+    });
+  });
+
+  describe('AC4: section value preserved in exercises list', () => {
+    it('returns the new section on the matching exercise', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1, section: 'primary' }),
+      ];
+      const { exercises: result } = applyChangeSection(exercises, 'ex1', 1, 'SS3');
+      expect(result[0].section).toBe('SS3');
+    });
+  });
+});
+
+describe('applyMoveUp', () => {
+  describe('AC3: reorder moves exercise up correctly', () => {
+    it('swaps exercise_order with the exercise above', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1, exercise_name: 'A' }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2, exercise_name: 'B' }),
+        makeExercise({ exercise_id: 'ex3', exercise_order: 3, exercise_name: 'C' }),
+      ];
+
+      const result = applyMoveUp(exercises, 'ex2', 2);
+
+      const sorted = [...result].sort((a, b) => a.exercise_order - b.exercise_order);
+      expect(sorted[0].exercise_name).toBe('B');
+      expect(sorted[1].exercise_name).toBe('A');
+      expect(sorted[2].exercise_name).toBe('C');
+    });
+
+    it('returns unchanged array when exercise is already first', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1 }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2 }),
+      ];
+
+      const result = applyMoveUp(exercises, 'ex1', 1);
+
+      // exercise_order unchanged
+      expect(result.find(e => e.exercise_id === 'ex1')?.exercise_order).toBe(1);
+      expect(result.find(e => e.exercise_id === 'ex2')?.exercise_order).toBe(2);
+    });
+
+    it('preserves exercise data when swapping', () => {
+      const set = makeSet({ set_number: 1, weight: '200', reps: '5' });
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1, sets: [set] }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2 }),
+      ];
+
+      const result = applyMoveUp(exercises, 'ex2', 2);
+
+      const ex1 = result.find(e => e.exercise_id === 'ex1');
+      expect(ex1?.sets[0].weight).toBe('200');
+    });
+  });
+});
+
+describe('applyMoveDown', () => {
+  describe('AC3: reorder moves exercise down correctly', () => {
+    it('swaps exercise_order with the exercise below', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1, exercise_name: 'A' }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2, exercise_name: 'B' }),
+        makeExercise({ exercise_id: 'ex3', exercise_order: 3, exercise_name: 'C' }),
+      ];
+
+      const result = applyMoveDown(exercises, 'ex2', 2);
+
+      const sorted = [...result].sort((a, b) => a.exercise_order - b.exercise_order);
+      expect(sorted[0].exercise_name).toBe('A');
+      expect(sorted[1].exercise_name).toBe('C');
+      expect(sorted[2].exercise_name).toBe('B');
+    });
+
+    it('returns unchanged array when exercise is already last', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1 }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2 }),
+      ];
+
+      const result = applyMoveDown(exercises, 'ex2', 2);
+
+      expect(result.find(e => e.exercise_id === 'ex2')?.exercise_order).toBe(2);
+    });
+
+    it('only affects the two exercises being swapped', () => {
+      const exercises = [
+        makeExercise({ exercise_id: 'ex1', exercise_order: 1 }),
+        makeExercise({ exercise_id: 'ex2', exercise_order: 2 }),
+        makeExercise({ exercise_id: 'ex3', exercise_order: 3 }),
+      ];
+
+      const result = applyMoveDown(exercises, 'ex1', 1);
+
+      expect(result.find(e => e.exercise_id === 'ex3')?.exercise_order).toBe(3);
+    });
+  });
+});

--- a/frontend/src/components/workout/section-management.ts
+++ b/frontend/src/components/workout/section-management.ts
@@ -1,0 +1,118 @@
+// Pure logic functions for section assignment, reorder, and remove in the workout tracker.
+
+import type { TrackerExercise } from './exercise-row';
+import type { TrackerSet } from './set-row';
+
+export const ALL_SECTIONS = ['warmup', 'primary', 'SS1', 'SS2', 'SS3', 'burnout', 'cooldown'] as const;
+export type SectionName = typeof ALL_SECTIONS[number];
+
+export interface SectionChangeResult {
+  exercises: TrackerExercise[];
+  /** Sets removed by this change (e.g. when converting to warmup). Caller must delete from API. */
+  removedSets: TrackerSet[];
+}
+
+/**
+ * Change the section of a specific exercise.
+ * - to warmup: clears all sets (returns them in removedSets for API deletion)
+ * - from warmup to non-warmup: adds a single empty set
+ * - non-warmup to non-warmup: just updates section, preserves sets
+ */
+export function applyChangeSection(
+  exercises: TrackerExercise[],
+  exerciseId: string,
+  exerciseOrder: number,
+  newSection: string,
+): SectionChangeResult {
+  let removedSets: TrackerSet[] = [];
+
+  const updated = exercises.map((ex) => {
+    if (ex.exercise_id !== exerciseId || ex.exercise_order !== exerciseOrder) return ex;
+
+    const wasWarmup = ex.section === 'warmup';
+    const toWarmup = newSection === 'warmup';
+
+    if (toWarmup) {
+      removedSets = [...ex.sets];
+      return { ...ex, section: newSection, sets: [] };
+    } else if (wasWarmup) {
+      const emptySet: TrackerSet = {
+        set_number: 1,
+        planned_reps: '',
+        weight: '',
+        reps: '',
+        effort: '',
+        notes: '',
+        saved: false,
+        sheetRow: -1,
+      };
+      return { ...ex, section: newSection, sets: [emptySet] };
+    } else {
+      return { ...ex, section: newSection };
+    }
+  });
+
+  return { exercises: updated, removedSets };
+}
+
+/**
+ * Swap exercise_order of the target exercise with the one above it.
+ * Returns the same array if already first.
+ */
+export function applyMoveUp(
+  exercises: TrackerExercise[],
+  exerciseId: string,
+  exerciseOrder: number,
+): TrackerExercise[] {
+  const sorted = [...exercises].sort((a, b) => a.exercise_order - b.exercise_order);
+  const idx = sorted.findIndex(
+    (e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder,
+  );
+  if (idx <= 0) return exercises;
+
+  const prevEx = sorted[idx - 1];
+  const currEx = sorted[idx];
+  const prevOrder = prevEx.exercise_order;
+  const currOrder = currEx.exercise_order;
+
+  return exercises.map((ex) => {
+    if (ex.exercise_id === currEx.exercise_id && ex.exercise_order === currOrder) {
+      return { ...ex, exercise_order: prevOrder };
+    }
+    if (ex.exercise_id === prevEx.exercise_id && ex.exercise_order === prevOrder) {
+      return { ...ex, exercise_order: currOrder };
+    }
+    return ex;
+  });
+}
+
+/**
+ * Swap exercise_order of the target exercise with the one below it.
+ * Returns the same array if already last.
+ */
+export function applyMoveDown(
+  exercises: TrackerExercise[],
+  exerciseId: string,
+  exerciseOrder: number,
+): TrackerExercise[] {
+  const sorted = [...exercises].sort((a, b) => a.exercise_order - b.exercise_order);
+  const idx = sorted.findIndex(
+    (e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder,
+  );
+  if (idx < 0 || idx >= sorted.length - 1) return exercises;
+
+  const nextEx = sorted[idx + 1];
+  const currEx = sorted[idx];
+  const currOrder = currEx.exercise_order;
+  const nextOrder = nextEx.exercise_order;
+
+  return exercises.map((ex) => {
+    if (ex.exercise_id === currEx.exercise_id && ex.exercise_order === currOrder) {
+      return { ...ex, exercise_order: nextOrder };
+    }
+    if (ex.exercise_id === nextEx.exercise_id && ex.exercise_order === nextOrder) {
+      return { ...ex, exercise_order: currOrder };
+    }
+    return ex;
+  });
+}

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -11,6 +11,7 @@ import type { ExerciseWithRow, Effort, SetWithRow } from '../../api/types';
 import { applyQuickFillWeight, applyQuickFillReps } from './quick-fill';
 import { applyCopyDown } from './copy-down';
 import { isWarmupExercise } from './warmup';
+import { applyChangeSection, applyMoveUp, applyMoveDown } from './section-management';
 
 interface Props {
   workoutId: string;
@@ -64,6 +65,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
   const [finishing, setFinishing] = useState(false);
   const [notes, setNotes] = useState('');
   const [showFinishForm, setShowFinishForm] = useState(false);
+  const [reorderAnnouncement, setReorderAnnouncement] = useState('');
   const saveTimers = useRef<Map<string, number>>(new Map());
 
   // Initialize from signal, merging warmup exercises (list-only, no sets)
@@ -320,6 +322,118 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
     );
   };
 
+  const handleChangeSection = async (exerciseId: string, exerciseOrder: number, newSection: string) => {
+    if (!token) return;
+    const { exercises: updated, removedSets } = applyChangeSection(exerciseList, exerciseId, exerciseOrder, newSection);
+
+    // Delete saved sets bottom-to-top when converting to warmup
+    const savedRemoved = removedSets
+      .filter((s) => s.sheetRow > 0)
+      .sort((a, b) => b.sheetRow - a.sheetRow);
+    for (const s of savedRemoved) {
+      const ex = exerciseList.find(
+        (e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder,
+      );
+      try {
+        await removeSet({
+          workout_id: workoutId,
+          exercise_id: exerciseId,
+          exercise_name: ex?.exercise_name ?? '',
+          section: ex?.section ?? '',
+          exercise_order: exerciseOrder,
+          set_number: s.set_number,
+          planned_reps: s.planned_reps,
+          weight: s.weight,
+          reps: s.reps,
+          effort: s.effort,
+          notes: s.notes,
+          sheetRow: s.sheetRow,
+        }, token);
+      } catch {
+        return; // Error toast shown by action
+      }
+    }
+
+    setExerciseList(updated);
+  };
+
+  const handleMoveUp = (exerciseId: string, exerciseOrder: number) => {
+    setExerciseList((prev) => {
+      const next = applyMoveUp(prev, exerciseId, exerciseOrder);
+      const sorted = [...next].sort((a, b) => a.exercise_order - b.exercise_order);
+      const movedEx = next.find(
+        (e) => e.exercise_id === exerciseId,
+      );
+      if (movedEx) {
+        const newPos = sorted.findIndex(
+          (e) => e.exercise_id === movedEx.exercise_id && e.exercise_order === movedEx.exercise_order,
+        ) + 1;
+        setReorderAnnouncement(
+          `${movedEx.exercise_name} moved to position ${newPos} of ${sorted.length}`,
+        );
+      }
+      return next;
+    });
+  };
+
+  const handleMoveDown = (exerciseId: string, exerciseOrder: number) => {
+    setExerciseList((prev) => {
+      const next = applyMoveDown(prev, exerciseId, exerciseOrder);
+      const sorted = [...next].sort((a, b) => a.exercise_order - b.exercise_order);
+      const movedEx = next.find(
+        (e) => e.exercise_id === exerciseId,
+      );
+      if (movedEx) {
+        const newPos = sorted.findIndex(
+          (e) => e.exercise_id === movedEx.exercise_id && e.exercise_order === movedEx.exercise_order,
+        ) + 1;
+        setReorderAnnouncement(
+          `${movedEx.exercise_name} moved to position ${newPos} of ${sorted.length}`,
+        );
+      }
+      return next;
+    });
+  };
+
+  const handleRemoveExercise = async (exerciseId: string, exerciseOrder: number) => {
+    if (!token) return;
+    const ex = exerciseList.find(
+      (e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder,
+    );
+    if (!ex) return;
+
+    if (!confirm(`Remove ${ex.exercise_name}? Logged sets will be deleted.`)) return;
+
+    // Delete saved sets bottom-to-top
+    const savedSets = ex.sets
+      .filter((s) => s.sheetRow > 0)
+      .sort((a, b) => b.sheetRow - a.sheetRow);
+    for (const s of savedSets) {
+      try {
+        await removeSet({
+          workout_id: workoutId,
+          exercise_id: exerciseId,
+          exercise_name: ex.exercise_name,
+          section: ex.section,
+          exercise_order: exerciseOrder,
+          set_number: s.set_number,
+          planned_reps: s.planned_reps,
+          weight: s.weight,
+          reps: s.reps,
+          effort: s.effort,
+          notes: s.notes,
+          sheetRow: s.sheetRow,
+        }, token);
+      } catch {
+        return; // Error toast shown by action
+      }
+    }
+
+    setExerciseList((prev) =>
+      prev.filter((e) => !(e.exercise_id === exerciseId && e.exercise_order === exerciseOrder)),
+    );
+  };
+
   const handleAddExercise = (ex: ExerciseWithRow) => {
     const maxOrder = exerciseList.reduce((max, e) => Math.max(max, e.exercise_order), 0);
     const newExercise: TrackerExercise = {
@@ -452,6 +566,15 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
         </div>
       )}
 
+      {/* aria-live region for reorder announcements */}
+      <div
+        role="status"
+        aria-live="polite"
+        class="sr-only"
+      >
+        {reorderAnnouncement}
+      </div>
+
       <div class="tracker-exercise-list">
         {exerciseList.length === 0 && (
           <div class="empty-state">
@@ -460,29 +583,41 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
           </div>
         )}
 
-        {exerciseList.map((ex) => (
-          <ExerciseRow
-            key={`${ex.exercise_id}-${ex.exercise_order}`}
-            exercise={ex}
-            currentWorkoutId={workoutId}
-            onUpdateSet={(setNum, updates) =>
-              handleUpdateSet(ex.exercise_id, ex.exercise_order, setNum, updates)
-            }
-            onAddSet={() => handleAddSet(ex.exercise_id, ex.exercise_order)}
-            onRemoveSet={(setNum) =>
-              handleRemoveSet(ex.exercise_id, ex.exercise_order, setNum)
-            }
-            onQuickFillWeight={(weight) =>
-              handleQuickFillWeight(ex.exercise_id, ex.exercise_order, weight)
-            }
-            onQuickFillReps={(reps) =>
-              handleQuickFillReps(ex.exercise_id, ex.exercise_order, reps)
-            }
-            onCopyDown={(lastTimeSets) =>
-              handleCopyDown(ex.exercise_id, ex.exercise_order, lastTimeSets)
-            }
-          />
-        ))}
+        {(() => {
+          const sorted = [...exerciseList].sort((a, b) => a.exercise_order - b.exercise_order);
+          return sorted.map((ex, idx) => (
+            <ExerciseRow
+              key={`${ex.exercise_id}-${ex.exercise_order}`}
+              exercise={ex}
+              currentWorkoutId={workoutId}
+              onUpdateSet={(setNum, updates) =>
+                handleUpdateSet(ex.exercise_id, ex.exercise_order, setNum, updates)
+              }
+              onAddSet={() => handleAddSet(ex.exercise_id, ex.exercise_order)}
+              onRemoveSet={(setNum) =>
+                handleRemoveSet(ex.exercise_id, ex.exercise_order, setNum)
+              }
+              onQuickFillWeight={(weight) =>
+                handleQuickFillWeight(ex.exercise_id, ex.exercise_order, weight)
+              }
+              onQuickFillReps={(reps) =>
+                handleQuickFillReps(ex.exercise_id, ex.exercise_order, reps)
+              }
+              onCopyDown={(lastTimeSets) =>
+                handleCopyDown(ex.exercise_id, ex.exercise_order, lastTimeSets)
+              }
+              onChangeSection={(newSection) =>
+                handleChangeSection(ex.exercise_id, ex.exercise_order, newSection)
+              }
+              onMoveUp={() => handleMoveUp(ex.exercise_id, ex.exercise_order)}
+              onMoveDown={() => handleMoveDown(ex.exercise_id, ex.exercise_order)}
+              onRemoveExercise={() => handleRemoveExercise(ex.exercise_id, ex.exercise_order)}
+              isFirst={idx === 0}
+              isLast={idx === sorted.length - 1}
+              totalExercises={sorted.length}
+            />
+          ));
+        })()}
       </div>
 
       <button

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -2119,3 +2119,133 @@ input, select, textarea {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
 }
+
+/* ===== Section Badge Button ===== */
+.section-badge-btn {
+  cursor: pointer;
+  border: none;
+  padding: 2px 8px;
+  min-height: 44px;
+  min-width: 44px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+/* ===== Section Picker Row ===== */
+.section-picker-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  padding: var(--space-xs) 0 var(--space-sm);
+}
+
+.section-picker-pill {
+  min-height: 44px;
+  padding: 0 var(--space-sm);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.1s;
+}
+
+.section-picker-pill:hover {
+  opacity: 0.85;
+}
+
+.section-picker-pill-active {
+  border-color: transparent;
+}
+
+/* ===== Warmup Confirmation Row ===== */
+.warmup-confirm-row {
+  padding: var(--space-sm) 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  margin: var(--space-xs) 0;
+}
+
+.warmup-confirm-text {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-sm);
+}
+
+.warmup-confirm-actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.warmup-confirm-actions .btn {
+  flex: 1;
+  min-height: 44px;
+}
+
+/* ===== Exercise Toolbar Row ===== */
+.exercise-toolbar-row {
+  display: flex;
+  gap: var(--space-xs);
+  padding: var(--space-xs) 0;
+}
+
+.exercise-toolbar-btn {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0 var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-raised);
+  color: var(--color-text-secondary);
+  font-size: var(--text-base);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.1s;
+}
+
+.exercise-toolbar-btn:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-border-strong, var(--color-border));
+}
+
+.exercise-toolbar-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.exercise-toolbar-remove {
+  margin-left: auto;
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.exercise-toolbar-remove:hover:not(:disabled) {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+/* Screen-reader only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
Closes #19

## Changes
- **section-management.ts** — Pure `applyChangeSection`, `applyMoveUp`, `applyMoveDown` functions + `ALL_SECTIONS` constant; 15 unit tests
- **exercise-row.tsx** — Section badge converted to `<button>` with `aria-label`; inline section picker pill row (flex-wrap, 44px touch targets); warmup confirmation row (danger + secondary); reorder/remove toolbar row; Escape key closes picker/confirm
- **workout-tracker.tsx** — `handleChangeSection` (deletes saved sets on warmup convert), `handleMoveUp`/`handleMoveDown` (with aria-live announcement), `handleRemoveExercise` (confirm dialog + bottom-to-top set deletion); exercises rendered sorted by order; `aria-live="polite"` region for reorder announcements
- **global.css** — `.section-badge-btn`, `.section-picker-row`, `.section-picker-pill`, `.warmup-confirm-row`, `.exercise-toolbar-row`, `.exercise-toolbar-btn`, `.sr-only`