### PR TITLE
fix: reserve saved checkmark space to prevent layout shift (#26)

### DIFF
--- a/frontend/src/components/workout/set-row.test.ts
+++ b/frontend/src/components/workout/set-row.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { SetRow } from './set-row';
+import type { TrackerSet } from './set-row';
+
+function makeSet(overrides: Partial<TrackerSet> = {}): TrackerSet {
+  return {
+    set_number: 1,
+    planned_reps: '',
+    weight: '135',
+    reps: '10',
+    effort: '',
+    notes: '',
+    saved: false,
+    sheetRow: -1,
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe('SetRow — saved checkmark layout (issue #26)', () => {
+  // AC1 + AC2: The .set-saved span is always in the DOM (reserves space)
+  it('always renders the .set-saved span regardless of saved state', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ saved: false }), onUpdate: noop, onRemove: noop })
+    );
+    const savedSpan = container.querySelector('.set-saved');
+    expect(savedSpan).not.toBeNull();
+    expect(savedSpan!.textContent).toBe('✓');
+  });
+
+  // AC2: When unsaved, span is visually hidden and aria-hidden="true"
+  it('hides the checkmark visually and from assistive tech when unsaved', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ saved: false }), onUpdate: noop, onRemove: noop })
+    );
+    const savedSpan = container.querySelector('.set-saved') as HTMLElement;
+    expect(savedSpan.style.visibility).toBe('hidden');
+    expect(savedSpan.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  // AC3: When saved, span is visible and aria-hidden="false"
+  it('shows the checkmark and exposes to assistive tech when saved', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ saved: true }), onUpdate: noop, onRemove: noop })
+    );
+    const savedSpan = container.querySelector('.set-saved') as HTMLElement;
+    expect(savedSpan.style.visibility).toBe('visible');
+    expect(savedSpan.getAttribute('aria-hidden')).toBe('false');
+    expect(savedSpan.getAttribute('aria-label')).toBe('Saved');
+  });
+
+  // AC4: Remove button is always present in a consistent position
+  it('always renders the remove button after the set-saved span', () => {
+    const { container: unsavedContainer } = render(
+      SetRow({ set: makeSet({ saved: false }), onUpdate: noop, onRemove: noop })
+    );
+    const { container: savedContainer } = render(
+      SetRow({ set: makeSet({ saved: true }), onUpdate: noop, onRemove: noop })
+    );
+
+    // Both should have the remove button
+    const unsavedRemove = unsavedContainer.querySelector('.set-remove-btn');
+    const savedRemove = savedContainer.querySelector('.set-remove-btn');
+    expect(unsavedRemove).not.toBeNull();
+    expect(savedRemove).not.toBeNull();
+
+    // The .set-saved span should come before .set-remove-btn in DOM order
+    const unsavedSaved = unsavedContainer.querySelector('.set-saved');
+    const unsavedParent = unsavedSaved!.parentElement!;
+    const children = Array.from(unsavedParent.children);
+    const savedIndex = children.indexOf(unsavedSaved as Element);
+    const removeIndex = children.indexOf(unsavedRemove as Element);
+    expect(savedIndex).toBeLessThan(removeIndex);
+  });
+});

--- a/frontend/src/components/workout/set-row.tsx
+++ b/frontend/src/components/workout/set-row.tsx
@@ -62,7 +62,14 @@ export function SetRow({ set, onUpdate, onRemove }: Props) {
         ))}
       </div>
 
-      {set.saved && <span class="set-saved" aria-label="Saved">✓</span>}
+      <span
+        class="set-saved"
+        style={{ visibility: set.saved ? 'visible' : 'hidden' }}
+        aria-label="Saved"
+        aria-hidden={set.saved ? 'false' : 'true'}
+      >
+        ✓
+      </span>
 
       <button
         class="set-remove-btn"


### PR DESCRIPTION
Closes #26

## Changes
- **`set-row.tsx`**: Always render the `.set-saved` span; use `visibility: hidden` when `saved === false` instead of conditional rendering. Toggle `aria-hidden` so screen readers only announce the checkmark when visible.
- **`set-row.test.ts`**: New test file with 4 tests covering all ACs (always-rendered span, hidden when unsaved, visible when saved, remove button position stable).

## Test plan
- [x] All 164 tests pass (`npm test`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Production build clean (`npm run build`)
- [ ] Manual: start workout, fill weight/reps, tap effort — checkmark appears without layout shift
- [ ] Manual: verify remove button stays in same position before/after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)