### PR TITLE
feat: quick-fill alignment and effort quick-fill (#28)

### DIFF
--- a/frontend/src/components/workout/copy-down.test.ts
+++ b/frontend/src/components/workout/copy-down.test.ts
@@ -27,6 +27,7 @@ function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise
     sets: [makeSet({ set_number: 1 }), makeSet({ set_number: 2 }), makeSet({ set_number: 3 })],
     quickFillWeight: '',
     quickFillReps: '',
+    quickFillEffort: '',
     ...overrides,
   };
 }

--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -3,7 +3,7 @@ import { SetRow } from './set-row';
 import { LastTimePanel } from './last-time-panel';
 import { ALL_SECTIONS } from './section-management';
 import type { TrackerSet } from './set-row';
-import type { SetWithRow } from '../../api/types';
+import type { Effort, SetWithRow } from '../../api/types';
 
 export interface TrackerExercise {
   exercise_id: string;
@@ -13,6 +13,7 @@ export interface TrackerExercise {
   sets: TrackerSet[];
   quickFillWeight: string;
   quickFillReps: string;
+  quickFillEffort: Effort | '';
 }
 
 interface Props {
@@ -23,6 +24,7 @@ interface Props {
   onRemoveSet: (setNumber: number) => void;
   onQuickFillWeight: (weight: string) => void;
   onQuickFillReps: (reps: string) => void;
+  onQuickFillEffort: (effort: Effort | '') => void;
   onCopyDown: (lastTimeSets: SetWithRow[]) => void;
   onChangeSection: (newSection: string) => void;
   onMoveUp: () => void;
@@ -53,6 +55,7 @@ export function ExerciseRow({
   onRemoveSet,
   onQuickFillWeight,
   onQuickFillReps,
+  onQuickFillEffort,
   onCopyDown,
   onChangeSection,
   onMoveUp,
@@ -268,29 +271,46 @@ export function ExerciseRow({
         />
       )}
 
+      <p class="quick-fill-heading">Quick fill</p>
       <div class="quick-fill-row">
-        <span class="quick-fill-label">Quick fill</span>
-        <input
-          id={`quick-fill-wt-${exercise.exercise_id}-${exercise.exercise_order}`}
-          class="form-input quick-fill-input"
-          type="number"
-          inputMode="decimal"
-          placeholder="lbs"
-          aria-label="Fill all sets weight (lbs)"
-          value={exercise.quickFillWeight}
-          onInput={(e) => onQuickFillWeight((e.target as HTMLInputElement).value)}
-        />
-        <span class="set-input-separator">×</span>
-        <input
-          id={`quick-fill-reps-${exercise.exercise_id}-${exercise.exercise_order}`}
-          class="form-input quick-fill-input"
-          type="number"
-          inputMode="numeric"
-          placeholder="reps"
-          aria-label="Fill all sets reps"
-          value={exercise.quickFillReps}
-          onInput={(e) => onQuickFillReps((e.target as HTMLInputElement).value)}
-        />
+        <span class="quick-fill-spacer" aria-hidden="true" />
+        <div class="set-inputs">
+          <input
+            id={`quick-fill-wt-${exercise.exercise_id}-${exercise.exercise_order}`}
+            class="form-input set-weight-input"
+            type="number"
+            inputMode="decimal"
+            placeholder="lbs"
+            aria-label="Fill all sets weight (lbs)"
+            value={exercise.quickFillWeight}
+            onInput={(e) => onQuickFillWeight((e.target as HTMLInputElement).value)}
+          />
+          <span class="set-input-separator">×</span>
+          <input
+            id={`quick-fill-reps-${exercise.exercise_id}-${exercise.exercise_order}`}
+            class="form-input set-reps-input"
+            type="number"
+            inputMode="numeric"
+            placeholder="reps"
+            aria-label="Fill all sets reps"
+            value={exercise.quickFillReps}
+            onInput={(e) => onQuickFillReps((e.target as HTMLInputElement).value)}
+          />
+        </div>
+        <div class="effort-toggle">
+          {(['Easy', 'Medium', 'Hard'] as Effort[]).map((e) => (
+            <button
+              key={e}
+              class={`effort-btn effort-btn-${e.toLowerCase()}${exercise.quickFillEffort === e ? ' active' : ''}`}
+              onClick={() => onQuickFillEffort(exercise.quickFillEffort === e ? '' : e)}
+              aria-label={`Fill all sets: ${e}`}
+              aria-pressed={exercise.quickFillEffort === e ? 'true' : 'false'}
+            >
+              {e === 'Easy' ? 'E' : e === 'Medium' ? 'M' : 'H'}
+            </button>
+          ))}
+        </div>
+        <span class="quick-fill-end-spacer" aria-hidden="true" />
       </div>
 
       <div class={`tracker-set-list${flashSets ? ' copy-down-flash' : ''}`}>

--- a/frontend/src/components/workout/quick-fill.test.ts
+++ b/frontend/src/components/workout/quick-fill.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyQuickFillWeight, applyQuickFillReps } from './quick-fill';
+import { applyQuickFillWeight, applyQuickFillReps, applyQuickFillEffort } from './quick-fill';
 import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
 
@@ -26,6 +26,7 @@ function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise
     sets: [makeSet({ set_number: 1 }), makeSet({ set_number: 2 }), makeSet({ set_number: 3 })],
     quickFillWeight: '',
     quickFillReps: '',
+    quickFillEffort: '',
     ...overrides,
   };
 }
@@ -229,5 +230,81 @@ describe('applyQuickFillReps', () => {
     expect(result[0].sets[1].reps).toBe('10');
     expect(result[0].sets[0].saved).toBe(false);
     expect(result[0].sets[1].saved).toBe(false);
+  });
+});
+
+describe('applyQuickFillEffort', () => {
+  // AC2: Effort quick-fill applies to all sets and marks unsaved
+  it('applies effort to all sets and marks them unsaved', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, effort: '', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, effort: '', saved: true, sheetRow: 3 }),
+        makeSet({ set_number: 3, effort: '', saved: true, sheetRow: 4 }),
+      ],
+    })];
+
+    const result = applyQuickFillEffort(exercises, 'ex1', 1, 'Medium');
+
+    expect(result[0].quickFillEffort).toBe('Medium');
+    expect(result[0].sets[0].effort).toBe('Medium');
+    expect(result[0].sets[1].effort).toBe('Medium');
+    expect(result[0].sets[2].effort).toBe('Medium');
+    expect(result[0].sets[0].saved).toBe(false);
+    expect(result[0].sets[1].saved).toBe(false);
+    expect(result[0].sets[2].saved).toBe(false);
+  });
+
+  // AC3: Toggle-off clears quickFillEffort but does not modify set efforts
+  it('does not clear existing set efforts when toggled off', () => {
+    const exercises = [makeExercise({
+      quickFillEffort: 'Medium',
+      sets: [
+        makeSet({ set_number: 1, effort: 'Medium', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, effort: 'Medium', saved: true, sheetRow: 3 }),
+      ],
+    })];
+
+    const result = applyQuickFillEffort(exercises, 'ex1', 1, '');
+
+    expect(result[0].quickFillEffort).toBe('');
+    // Set efforts should NOT be cleared
+    expect(result[0].sets[0].effort).toBe('Medium');
+    expect(result[0].sets[1].effort).toBe('Medium');
+    // Saved status should be preserved
+    expect(result[0].sets[0].saved).toBe(true);
+    expect(result[0].sets[1].saved).toBe(true);
+  });
+
+  // AC4: Effort quick-fill does not modify weight or reps
+  it('does not modify weight or reps values', () => {
+    const exercises = [makeExercise({
+      sets: [
+        makeSet({ set_number: 1, weight: '135', reps: '10', effort: '', saved: true, sheetRow: 2 }),
+        makeSet({ set_number: 2, weight: '185', reps: '8', effort: '', saved: true, sheetRow: 3 }),
+      ],
+    })];
+
+    const result = applyQuickFillEffort(exercises, 'ex1', 1, 'Hard');
+
+    expect(result[0].sets[0].weight).toBe('135');
+    expect(result[0].sets[0].reps).toBe('10');
+    expect(result[0].sets[1].weight).toBe('185');
+    expect(result[0].sets[1].reps).toBe('8');
+    expect(result[0].sets[0].effort).toBe('Hard');
+    expect(result[0].sets[1].effort).toBe('Hard');
+  });
+
+  it('only affects the matching exercise', () => {
+    const exercises = [
+      makeExercise({ exercise_id: 'ex1', exercise_order: 1 }),
+      makeExercise({ exercise_id: 'ex2', exercise_order: 2, exercise_name: 'Squat' }),
+    ];
+
+    const result = applyQuickFillEffort(exercises, 'ex1', 1, 'Easy');
+
+    expect(result[0].sets[0].effort).toBe('Easy');
+    expect(result[1].sets[0].effort).toBe('');
+    expect(result[1].quickFillEffort).toBe('');
   });
 });

--- a/frontend/src/components/workout/quick-fill.ts
+++ b/frontend/src/components/workout/quick-fill.ts
@@ -1,4 +1,5 @@
 import type { TrackerExercise } from './exercise-row';
+import type { Effort } from '../../api/types';
 
 /**
  * Apply quick-fill weight to all sets for a matching exercise.
@@ -43,6 +44,30 @@ export function applyQuickFillReps(
       sets: ex.sets.map((s) => {
         if (!reps) return s;
         return { ...s, reps, saved: false };
+      }),
+    };
+  });
+}
+
+/**
+ * Apply quick-fill effort to all sets for a matching exercise.
+ * When effort is non-empty, overwrites all set efforts and marks unsaved.
+ * When effort is empty (toggled off), only clears quickFillEffort (preserves existing set efforts).
+ */
+export function applyQuickFillEffort(
+  exercises: TrackerExercise[],
+  exerciseId: string,
+  exerciseOrder: number,
+  effort: Effort | '',
+): TrackerExercise[] {
+  return exercises.map((ex) => {
+    if (ex.exercise_id !== exerciseId || ex.exercise_order !== exerciseOrder) return ex;
+    return {
+      ...ex,
+      quickFillEffort: effort,
+      sets: ex.sets.map((s) => {
+        if (!effort) return s;
+        return { ...s, effort, saved: false };
       }),
     };
   });

--- a/frontend/src/components/workout/section-management.test.ts
+++ b/frontend/src/components/workout/section-management.test.ts
@@ -26,6 +26,7 @@ function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise
     sets: [makeSet({ set_number: 1 }), makeSet({ set_number: 2 })],
     quickFillWeight: '',
     quickFillReps: '',
+    quickFillEffort: '',
     ...overrides,
   };
 }

--- a/frontend/src/components/workout/warmup.test.ts
+++ b/frontend/src/components/workout/warmup.test.ts
@@ -26,6 +26,7 @@ function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise
     sets: [],
     quickFillWeight: '',
     quickFillReps: '',
+    quickFillEffort: '',
     ...overrides,
   };
 }

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -8,7 +8,7 @@ import { ExerciseRow } from './exercise-row';
 import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
 import type { ExerciseWithRow, Effort, SetWithRow } from '../../api/types';
-import { applyQuickFillWeight, applyQuickFillReps } from './quick-fill';
+import { applyQuickFillWeight, applyQuickFillReps, applyQuickFillEffort } from './quick-fill';
 import { applyCopyDown } from './copy-down';
 import { isWarmupExercise } from './warmup';
 import { applyChangeSection, applyMoveUp, applyMoveDown } from './section-management';
@@ -35,6 +35,7 @@ function buildExerciseList(setRows: typeof activeWorkoutSets.value): TrackerExer
         sets: [],
         quickFillWeight: '',
         quickFillReps: '',
+        quickFillEffort: '',
       };
       map.set(key, ex);
     }
@@ -79,6 +80,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
       sets: [],
       quickFillWeight: '',
       quickFillReps: '',
+      quickFillEffort: '',
     }));
     const merged = [...warmups, ...tracked].sort((a, b) => a.exercise_order - b.exercise_order);
     setExerciseList(merged);
@@ -198,6 +200,23 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
         if (ex) {
           for (const s of ex.sets) {
             if (s.weight) {
+              setTimeout(() => debouncedSave(exerciseOrder, exerciseId, s), 0);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const handleQuickFillEffort = (exerciseId: string, exerciseOrder: number, effort: Effort | '') => {
+    setExerciseList((prev) => {
+      const next = applyQuickFillEffort(prev, exerciseId, exerciseOrder, effort);
+      if (effort) {
+        const ex = next.find((e) => e.exercise_id === exerciseId && e.exercise_order === exerciseOrder);
+        if (ex) {
+          for (const s of ex.sets) {
+            if (s.weight || s.reps) {
               setTimeout(() => debouncedSave(exerciseOrder, exerciseId, s), 0);
             }
           }
@@ -453,6 +472,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
       }],
       quickFillWeight: '',
       quickFillReps: '',
+      quickFillEffort: '',
     };
     setExerciseList((prev) => [...prev, newExercise]);
     setShowExercisePicker(false);
@@ -602,6 +622,9 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
               }
               onQuickFillReps={(reps) =>
                 handleQuickFillReps(ex.exercise_id, ex.exercise_order, reps)
+              }
+              onQuickFillEffort={(effort) =>
+                handleQuickFillEffort(ex.exercise_id, ex.exercise_order, effort)
               }
               onCopyDown={(lastTimeSets) =>
                 handleCopyDown(ex.exercise_id, ex.exercise_order, lastTimeSets)

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1237,26 +1237,27 @@ input, select, textarea {
   font-size: var(--text-base);
 }
 
-.quick-fill-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-sm);
-}
-
-.quick-fill-label {
+.quick-fill-heading {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-text-secondary);
-  white-space: nowrap;
+  margin: 0 0 var(--space-xs) 0;
 }
 
-.quick-fill-input {
-  flex: 1;
-  min-width: 64px;
-  min-height: 44px;
-  padding: var(--space-xs) var(--space-sm);
-  font-size: var(--text-sm);
+.quick-fill-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.quick-fill-spacer {
+  min-width: 24px;
+}
+
+.quick-fill-end-spacer {
+  /* set-saved (16px) + gap (4px) + set-remove-btn (24px) */
+  min-width: 44px;
 }
 
 .tracker-set-list {


### PR DESCRIPTION
Closes #28

## Changes
- **`exercise-row.tsx`**: Added `quickFillEffort` to `TrackerExercise` interface and `onQuickFillEffort` prop. Restructured quick-fill row: moved "Quick fill" label above as `<p class="quick-fill-heading">`, added spacer matching set number column (24px), reused `set-inputs`/`set-weight-input`/`set-reps-input` classes for alignment, added E/M/H effort buttons with `aria-pressed` and `aria-label="Fill all sets: ..."`, added end spacer matching saved checkmark + remove button width.
- **`quick-fill.ts`**: Added `applyQuickFillEffort` following the same pattern as weight/reps — applies effort to all sets when non-empty, only clears `quickFillEffort` when empty (preserves individual set efforts).
- **`quick-fill.test.ts`**: 4 new tests covering AC2 (apply to all sets), AC3 (toggle-off preserves), AC4 (independent of weight/reps), and exercise isolation.
- **`workout-tracker.tsx`**: Added `handleQuickFillEffort` handler with auto-save scheduling, prop pass-through, and `quickFillEffort: ''` initialization in all exercise creation paths.
- **`global.css`**: Replaced `.quick-fill-label` and `.quick-fill-input` with `.quick-fill-heading`, `.quick-fill-spacer` (24px), and `.quick-fill-end-spacer` (44px). Quick-fill row now uses `gap: var(--space-xs)` matching tracker-set rows.
- **Test files**: Updated `makeExercise` helpers in `copy-down.test.ts`, `section-management.test.ts`, `warmup.test.ts` to include `quickFillEffort: ''`.

## Test plan
- [x] All 168 tests pass (`npm test`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Production build clean (`npm run build`)
- [ ] Manual: verify quick-fill weight/reps columns align with set row columns below
- [ ] Manual: verify effort E/M/H quick-fill buttons align with set row effort buttons
- [ ] Manual: tap effort quick-fill → all sets get effort applied
- [ ] Manual: tap active effort quick-fill again → quick-fill clears but set efforts preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)