### PR TITLE
feat: replace G lettermark with weight-rack icon set

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,8 @@
   <title>Groundwork — Workout Tracker</title>
   <link rel="manifest" href="/groundwork/manifest.json" />
   <meta name="theme-color" content="#4f6ef7" />
-  <link rel="icon" href="/groundwork/icon-192.svg" type="image/svg+xml" />
+  <link rel="icon" type="image/svg+xml" sizes="any" href="/groundwork/groundwork-favicon.svg" />
+  <link rel="apple-touch-icon" href="/groundwork/groundwork-icon-192.svg" />
   <!-- Apply data-theme before first paint to prevent flash of wrong theme -->
   <script>
     (function() {

--- a/frontend/public/groundwork-favicon.svg
+++ b/frontend/public/groundwork-favicon.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="12" fill="#4f6ef7"/>
+  <rect x="10" y="42" width="44" height="3" fill="white"/>
+  <rect x="24" y="32" width="16" height="3" fill="white"/>
+  <rect x="19" y="29" width="4" height="9" fill="white"/>
+  <rect x="41" y="29" width="4" height="9" fill="white"/>
+</svg>

--- a/frontend/public/groundwork-icon-192-maskable.svg
+++ b/frontend/public/groundwork-icon-192-maskable.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
+  <rect width="192" height="192" fill="#4f6ef7"/>
+  <g transform="translate(48, 48) scale(1.5)">
+    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
+    <rect x="20" y="30" width="24" height="4" fill="white"/>
+    <rect x="14" y="26" width="4" height="12" fill="white"/>
+    <rect x="10" y="28" width="3" height="8" fill="white"/>
+    <rect x="46" y="26" width="4" height="12" fill="white"/>
+    <rect x="51" y="28" width="3" height="8" fill="white"/>
+  </g>
+</svg>

--- a/frontend/public/groundwork-icon-192.svg
+++ b/frontend/public/groundwork-icon-192.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
+  <rect width="192" height="192" rx="32" fill="#4f6ef7"/>
+  <g transform="translate(32, 32) scale(2)">
+    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
+    <rect x="20" y="30" width="24" height="4" fill="white"/>
+    <rect x="14" y="26" width="4" height="12" fill="white"/>
+    <rect x="10" y="28" width="3" height="8" fill="white"/>
+    <rect x="46" y="26" width="4" height="12" fill="white"/>
+    <rect x="51" y="28" width="3" height="8" fill="white"/>
+  </g>
+</svg>

--- a/frontend/public/groundwork-icon-512-maskable.svg
+++ b/frontend/public/groundwork-icon-512-maskable.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" fill="#4f6ef7"/>
+  <g transform="translate(128, 128) scale(4)">
+    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
+    <rect x="20" y="30" width="24" height="4" fill="white"/>
+    <rect x="14" y="26" width="4" height="12" fill="white"/>
+    <rect x="10" y="28" width="3" height="8" fill="white"/>
+    <rect x="46" y="26" width="4" height="12" fill="white"/>
+    <rect x="51" y="28" width="3" height="8" fill="white"/>
+  </g>
+</svg>

--- a/frontend/public/groundwork-icon-512.svg
+++ b/frontend/public/groundwork-icon-512.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="80" fill="#4f6ef7"/>
+  <g transform="translate(96, 96) scale(5)">
+    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
+    <rect x="20" y="30" width="24" height="4" fill="white"/>
+    <rect x="14" y="26" width="4" height="12" fill="white"/>
+    <rect x="10" y="28" width="3" height="8" fill="white"/>
+    <rect x="46" y="26" width="4" height="12" fill="white"/>
+    <rect x="51" y="28" width="3" height="8" fill="white"/>
+  </g>
+</svg>

--- a/frontend/public/groundwork-icon-compact.svg
+++ b/frontend/public/groundwork-icon-compact.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <rect x="10" y="42" width="44" height="3"/>
+  <rect x="24" y="32" width="16" height="3"/>
+  <rect x="19" y="29" width="4" height="9"/>
+  <rect x="41" y="29" width="4" height="9"/>
+</svg>

--- a/frontend/public/groundwork-icon-minimal.svg
+++ b/frontend/public/groundwork-icon-minimal.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <rect x="12" y="40" width="40" height="3"/>
+  <rect x="26" y="32" width="12" height="3"/>
+  <rect x="22" y="30" width="3" height="7"/>
+  <rect x="39" y="30" width="3" height="7"/>
+</svg>

--- a/frontend/public/groundwork-icon-primary.svg
+++ b/frontend/public/groundwork-icon-primary.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <rect x="6" y="44" width="52" height="4" rx="1"/>
+  <rect x="20" y="30" width="24" height="4"/>
+  <rect x="14" y="26" width="4" height="12"/>
+  <rect x="10" y="28" width="3" height="8"/>
+  <rect x="46" y="26" width="4" height="12"/>
+  <rect x="51" y="28" width="3" height="8"/>
+</svg>

--- a/frontend/public/icon-192.svg
+++ b/frontend/public/icon-192.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" fill="none">
-  <rect width="192" height="192" rx="32" fill="#4f6ef7"/>
-  <text x="96" y="120" text-anchor="middle" font-size="100" font-family="system-ui, sans-serif" font-weight="700" fill="white">G</text>
-</svg>

--- a/frontend/public/icon-512.svg
+++ b/frontend/public/icon-512.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
-  <rect width="512" height="512" rx="80" fill="#4f6ef7"/>
-  <text x="256" y="330" text-anchor="middle" font-size="280" font-family="system-ui, sans-serif" font-weight="700" fill="white">G</text>
-</svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -8,14 +8,28 @@
   "theme_color": "#4f6ef7",
   "icons": [
     {
-      "src": "icon-192.svg",
+      "src": "groundwork-icon-192.svg",
       "sizes": "192x192",
-      "type": "image/svg+xml"
+      "type": "image/svg+xml",
+      "purpose": "any"
     },
     {
-      "src": "icon-512.svg",
+      "src": "groundwork-icon-192-maskable.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    },
+    {
+      "src": "groundwork-icon-512.svg",
       "sizes": "512x512",
-      "type": "image/svg+xml"
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "groundwork-icon-512-maskable.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
Closes #30

## Changes
- Added 3 source SVG variants (`groundwork-icon-minimal.svg`, `groundwork-icon-compact.svg`, `groundwork-icon-primary.svg`) with `fill="currentColor"` for future in-app use
- Created `groundwork-favicon.svg` — compact variant on `#4f6ef7` rounded-rect background for clear browser tab display
- Created PWA icon SVGs at 192×192 and 512×512 with separate `any` and `maskable` purpose entries (maskable variants have safe-zone padding to ~60% canvas)
- Added `<link rel="apple-touch-icon">` for iOS home screen
- Updated `manifest.json` with 4 icon entries (2 sizes × 2 purposes)
- Removed old `icon-192.svg` and `icon-512.svg` placeholder G lettermarks