### PR TITLE
fix: warmup card button alignment and Activities heading

### DIFF
--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -10,7 +10,7 @@ export function ActivitiesScreen() {
     <div class="screen activities-screen">
       <header class="screen-header">
         <div class="activities-header-row">
-          <h1>Workouts</h1>
+          <h1>Activities</h1>
           <button
             class="btn-icon"
             onClick={() => setShowFilters(!showFilters)}

--- a/frontend/src/components/workout/exercise-row.test.ts
+++ b/frontend/src/components/workout/exercise-row.test.ts
@@ -183,18 +183,29 @@ describe('AC4: Quick fill section uses border-top divider instead of text label'
   });
 });
 
-describe('AC5: Warmup cards are unaffected', () => {
-  it('warmup cards do not use the new controls row layout', () => {
+describe('AC5: Warmup cards use same controls layout as other sections', () => {
+  it('warmup cards use tracker-exercise-controls with right-aligned action buttons', () => {
     const { container } = renderExerciseRow({ section: 'warmup' }, { totalExercises: 3 });
-    // Warmup cards should NOT have the new controls row
     const controlsRow = container.querySelector('.tracker-exercise-controls');
-    expect(controlsRow).toBeNull();
-    // Should still have the old header
-    const header = container.querySelector('.tracker-exercise-header');
-    expect(header).not.toBeNull();
-    // Should still have toolbar row below header
+    expect(controlsRow).not.toBeNull();
+    // Section badge inside controls row
+    const badge = controlsRow!.querySelector('.section-badge-btn');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe('warmup');
+    // Exercise name inside controls row
+    const name = controlsRow!.querySelector('.tracker-exercise-name');
+    expect(name).not.toBeNull();
+    // Action buttons inside tracker-exercise-actions (right-aligned)
+    const actions = controlsRow!.querySelector('.tracker-exercise-actions');
+    expect(actions).not.toBeNull();
+    const buttons = actions!.querySelectorAll('.exercise-toolbar-btn');
+    expect(buttons.length).toBe(3); // ▲ ▼ ✕
+  });
+
+  it('warmup cards do not render the old exercise-toolbar-row', () => {
+    const { container } = renderExerciseRow({ section: 'warmup' }, { totalExercises: 3 });
     const toolbar = container.querySelector('.exercise-toolbar-row');
-    expect(toolbar).not.toBeNull();
+    expect(toolbar).toBeNull();
   });
 
   it('warmup cards do not render quick fill section', () => {

--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -128,6 +128,37 @@ export function ExerciseRow({
 
   const showToolbar = totalExercises > 1;
 
+  const actionButtons = showToolbar && (
+    <>
+      <button
+        type="button"
+        class="exercise-toolbar-btn"
+        onClick={onMoveUp}
+        disabled={isFirst}
+        aria-label={`Move ${exercise.exercise_name} up`}
+      >
+        ▲
+      </button>
+      <button
+        type="button"
+        class="exercise-toolbar-btn"
+        onClick={onMoveDown}
+        disabled={isLast}
+        aria-label={`Move ${exercise.exercise_name} down`}
+      >
+        ▼
+      </button>
+      <button
+        type="button"
+        class="exercise-toolbar-btn exercise-toolbar-remove"
+        onClick={onRemoveExercise}
+        aria-label={`Remove ${exercise.exercise_name}`}
+      >
+        ✕
+      </button>
+    </>
+  );
+
   const sectionPickerRow = showSectionPicker && (
     <div class="section-picker-row" role="group" aria-label="Select section">
       {ALL_SECTIONS.map((s) => (
@@ -168,37 +199,6 @@ export function ExerciseRow({
     </div>
   );
 
-  const toolbarRow = showToolbar && (
-    <div class="exercise-toolbar-row">
-      <button
-        type="button"
-        class="exercise-toolbar-btn"
-        onClick={onMoveUp}
-        disabled={isFirst}
-        aria-label={`Move ${exercise.exercise_name} up`}
-      >
-        ▲
-      </button>
-      <button
-        type="button"
-        class="exercise-toolbar-btn"
-        onClick={onMoveDown}
-        disabled={isLast}
-        aria-label={`Move ${exercise.exercise_name} down`}
-      >
-        ▼
-      </button>
-      <button
-        type="button"
-        class="exercise-toolbar-btn exercise-toolbar-remove"
-        onClick={onRemoveExercise}
-        aria-label={`Remove ${exercise.exercise_name}`}
-      >
-        ✕
-      </button>
-    </div>
-  );
-
   // Warmup exercises render as simplified name-only cards
   if (isWarmup) {
     return (
@@ -206,7 +206,7 @@ export function ExerciseRow({
         class="tracker-exercise tracker-exercise-warmup"
         aria-label={`Warmup: ${exercise.exercise_name} (list only)`}
       >
-        <div class="tracker-exercise-header">
+        <div class="tracker-exercise-controls">
           <button
             type="button"
             class={`${sectionBadgeClass(exercise.section)} section-badge-btn`}
@@ -217,10 +217,12 @@ export function ExerciseRow({
             {exercise.section}
           </button>
           <span class="tracker-exercise-name">{exercise.exercise_name}</span>
+          <div class="tracker-exercise-actions">
+            {actionButtons}
+          </div>
         </div>
         {sectionPickerRow}
         {warmupConfirmRow}
-        {toolbarRow}
       </div>
     );
   }
@@ -253,36 +255,7 @@ export function ExerciseRow({
               <polyline points="12 6 12 12 16 14" />
             </svg>
           </button>
-          {showToolbar && (
-            <>
-              <button
-                type="button"
-                class="exercise-toolbar-btn"
-                onClick={onMoveUp}
-                disabled={isFirst}
-                aria-label={`Move ${exercise.exercise_name} up`}
-              >
-                ▲
-              </button>
-              <button
-                type="button"
-                class="exercise-toolbar-btn"
-                onClick={onMoveDown}
-                disabled={isLast}
-                aria-label={`Move ${exercise.exercise_name} down`}
-              >
-                ▼
-              </button>
-              <button
-                type="button"
-                class="exercise-toolbar-btn exercise-toolbar-remove"
-                onClick={onRemoveExercise}
-                aria-label={`Remove ${exercise.exercise_name}`}
-              >
-                ✕
-              </button>
-            </>
-          )}
+          {actionButtons}
         </div>
       </div>
 

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1217,8 +1217,12 @@ input, select, textarea {
   padding: var(--space-sm) var(--space-md);
 }
 
-.tracker-exercise-warmup .tracker-exercise-header {
+.tracker-exercise-warmup .tracker-exercise-controls {
   margin-bottom: 0;
+}
+
+.tracker-exercise-warmup .tracker-exercise-name {
+  flex: 1;
 }
 
 [data-theme="dark"] .tracker-exercise-warmup {


### PR DESCRIPTION
Closes #35

## Changes
- **Warmup card buttons**: Changed warmup exercise cards to use the same `tracker-exercise-controls` + `tracker-exercise-actions` layout as PRIMARY/SS cards, so move/delete buttons are right-aligned in the header row instead of appearing as a separate block below the name
- **Activities heading**: Changed `<h1>Workouts</h1>` → `<h1>Activities</h1>` to match the bottom nav tab label
- Extracted shared `actionButtons` fragment to eliminate duplication between warmup and non-warmup paths
- Updated tests to verify new warmup layout

## Test plan
- [x] All 181 existing tests pass
- [x] TypeScript type check clean
- [x] Production build succeeds
- [ ] Visual verification: warmup card buttons right-aligned, matching other sections
- [ ] Activities screen heading reads "Activities"

🤖 Generated with [Claude Code](https://claude.com/claude-code)