### PR TITLE
fix: exercise selector modal padding (#36)

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -873,6 +873,19 @@ input, select, textarea {
   transition: background var(--transition-fast);
 }
 
+.exercise-list > .exercise-list-item {
+  padding: var(--space-md) var(--space-lg);
+  cursor: pointer;
+}
+
+.exercise-list > .exercise-list-item:hover {
+  background: var(--color-border-light);
+}
+
+.exercise-list > .exercise-list-item:active {
+  background: var(--color-primary-light);
+}
+
 .exercise-list-item-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #36

## Changes
- Added `padding: var(--space-md) var(--space-lg)` to exercise list items within the Select Exercise modal
- Added hover/active states matching the exercises screen pattern
- Scoped to `.exercise-list > .exercise-list-item` so the exercises screen (which uses its own `-header` wrapper) is unaffected