### PR TITLE
feat: activities list visual improvements (#38)

### DIFF
--- a/frontend/src/components/activities/activities-helpers.test.ts
+++ b/frontend/src/components/activities/activities-helpers.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { groupWorkoutsByDate, getWorkoutTags, EQUIPMENT_TAGS } from './activities-helpers';
+import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/types';
+
+function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
+  return {
+    id: 'w1',
+    date: '2026-03-15',
+    time: '07:00',
+    type: 'weight',
+    name: 'Upper Push A',
+    template_id: '',
+    notes: '',
+    duration_min: '60',
+    created: '',
+    copied_from: '',
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+// ── Date grouping ────────────────────────────────────────────────────
+
+describe('groupWorkoutsByDate', () => {
+  // Use 2026-03-15 (Sunday) as "today"
+  const today = '2026-03-15';
+
+  it('returns empty array for no workouts', () => {
+    expect(groupWorkoutsByDate([], today)).toEqual([]);
+  });
+
+  it('groups a workout from today into "This Week"', () => {
+    const workouts = [makeWorkout({ date: '2026-03-15' })];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('This Week');
+    expect(groups[0].workouts).toHaveLength(1);
+  });
+
+  it('groups workouts from current Mon-Sun into "This Week"', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09' }), // Monday of this week
+      makeWorkout({ id: 'w2', date: '2026-03-15' }), // Sunday (today)
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('This Week');
+    expect(groups[0].workouts).toHaveLength(2);
+  });
+
+  it('groups previous week into "Last Week"', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-02' }), // Mon of last week
+      makeWorkout({ id: 'w2', date: '2026-03-08' }), // Sun of last week
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('Last Week');
+    expect(groups[0].workouts).toHaveLength(2);
+  });
+
+  it('groups older workouts by month/year', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-02-15' }),
+      makeWorkout({ id: 'w2', date: '2026-02-20' }),
+      makeWorkout({ id: 'w3', date: '2026-01-05' }),
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].label).toBe('February 2026');
+    expect(groups[0].workouts).toHaveLength(2);
+    expect(groups[1].label).toBe('January 2026');
+    expect(groups[1].workouts).toHaveLength(1);
+  });
+
+  it('handles mixed groups in correct order', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-15' }),  // This Week
+      makeWorkout({ id: 'w2', date: '2026-03-05' }),  // Last Week
+      makeWorkout({ id: 'w3', date: '2026-02-10' }),  // February
+      makeWorkout({ id: 'w4', date: '2026-01-20' }),  // January
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups.map(g => g.label)).toEqual([
+      'This Week',
+      'Last Week',
+      'February 2026',
+      'January 2026',
+    ]);
+  });
+
+  it('omits empty groups', () => {
+    // Only a workout in "last week" — no "This Week" group should appear
+    const workouts = [makeWorkout({ date: '2026-03-05' })];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('Last Week');
+  });
+});
+
+// ── Tag aggregation ──────────────────────────────────────────────────
+
+describe('getWorkoutTags', () => {
+  const exercises: ExerciseWithRow[] = [
+    { id: 'ex1', name: 'Bench Press BB', tags: 'Push, Chest, BB', notes: '', created: '', sheetRow: 2 },
+    { id: 'ex2', name: 'Incline Press DB', tags: 'Push, Chest, DB', notes: '', created: '', sheetRow: 3 },
+    { id: 'ex3', name: 'Lateral Raise DB', tags: 'Push, Shoulders, DB', notes: '', created: '', sheetRow: 4 },
+    { id: 'ex4', name: 'Ab Wheel', tags: 'Core', notes: '', created: '', sheetRow: 5 },
+  ];
+
+  const workoutSets: SetWithRow[] = [
+    { workout_id: 'w1', exercise_id: 'ex1', exercise_name: 'Bench Press BB', section: 'primary', exercise_order: 1, set_number: 1, planned_reps: '', weight: '185', reps: '6', effort: 'Medium', notes: '', sheetRow: 2 },
+    { workout_id: 'w1', exercise_id: 'ex2', exercise_name: 'Incline Press DB', section: 'SS1', exercise_order: 2, set_number: 1, planned_reps: '', weight: '55', reps: '12', effort: 'Medium', notes: '', sheetRow: 3 },
+    { workout_id: 'w1', exercise_id: 'ex3', exercise_name: 'Lateral Raise DB', section: 'SS2', exercise_order: 3, set_number: 1, planned_reps: '', weight: '15', reps: '15', effort: 'Easy', notes: '', sheetRow: 4 },
+    { workout_id: 'w1', exercise_id: 'ex4', exercise_name: 'Ab Wheel', section: 'burnout', exercise_order: 4, set_number: 1, planned_reps: '', weight: '', reps: '10', effort: 'Medium', notes: '', sheetRow: 5 },
+  ];
+
+  it('returns top 3 most common muscle group tags', () => {
+    const tags = getWorkoutTags(workoutSets, exercises);
+    // Push appears on ex1, ex2, ex3 = 3 times
+    // Chest appears on ex1, ex2 = 2 times
+    // Shoulders appears on ex3 = 1 time
+    // Core appears on ex4 = 1 time
+    expect(tags).toHaveLength(3);
+    expect(tags[0]).toBe('Push'); // 3 occurrences
+    expect(tags[1]).toBe('Chest'); // 2 occurrences
+    // Third could be Shoulders or Core (both 1); alphabetical tiebreak
+    expect(['Core', 'Shoulders']).toContain(tags[2]);
+  });
+
+  it('excludes equipment tags (BB, DB, FT)', () => {
+    const tags = getWorkoutTags(workoutSets, exercises);
+    for (const tag of tags) {
+      expect(EQUIPMENT_TAGS).not.toContain(tag);
+    }
+  });
+
+  it('returns empty array for empty sets', () => {
+    expect(getWorkoutTags([], exercises)).toEqual([]);
+  });
+
+  it('returns empty array when exercises have no tags', () => {
+    const noTagExercises: ExerciseWithRow[] = [
+      { id: 'ex1', name: 'Custom Exercise', tags: '', notes: '', created: '', sheetRow: 2 },
+    ];
+    const singleSet: SetWithRow[] = [
+      { workout_id: 'w1', exercise_id: 'ex1', exercise_name: 'Custom Exercise', section: 'primary', exercise_order: 1, set_number: 1, planned_reps: '', weight: '', reps: '', effort: '', notes: '', sheetRow: 2 },
+    ];
+    expect(getWorkoutTags(singleSet, noTagExercises)).toEqual([]);
+  });
+
+  it('returns fewer than 3 if not enough unique tags', () => {
+    const singleEx: ExerciseWithRow[] = [
+      { id: 'ex4', name: 'Ab Wheel', tags: 'Core', notes: '', created: '', sheetRow: 5 },
+    ];
+    const singleSet: SetWithRow[] = [
+      { workout_id: 'w1', exercise_id: 'ex4', exercise_name: 'Ab Wheel', section: 'burnout', exercise_order: 1, set_number: 1, planned_reps: '', weight: '', reps: '10', effort: '', notes: '', sheetRow: 2 },
+    ];
+    const tags = getWorkoutTags(singleSet, singleEx);
+    expect(tags).toEqual(['Core']);
+  });
+
+  it('excludes Warmup tag', () => {
+    const warmupEx: ExerciseWithRow[] = [
+      { id: 'ex1', name: 'Push Ups', tags: 'Warmup, Push, Chest', notes: '', created: '', sheetRow: 2 },
+    ];
+    const warmupSets: SetWithRow[] = [
+      { workout_id: 'w1', exercise_id: 'ex1', exercise_name: 'Push Ups', section: 'warmup', exercise_order: 1, set_number: 1, planned_reps: '', weight: '', reps: '15', effort: '', notes: '', sheetRow: 2 },
+    ];
+    const tags = getWorkoutTags(warmupSets, warmupEx);
+    expect(tags).not.toContain('Warmup');
+    expect(tags).toContain('Push');
+    expect(tags).toContain('Chest');
+  });
+});

--- a/frontend/src/components/activities/activities-helpers.ts
+++ b/frontend/src/components/activities/activities-helpers.ts
@@ -1,0 +1,102 @@
+import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/types';
+
+// ── Equipment / non-muscle tags to exclude from card pills ───────────
+export const EQUIPMENT_TAGS = new Set(['BB', 'DB', 'FT', 'Warmup']);
+
+// ── Date grouping ────────────────────────────────────────────────────
+
+export interface WorkoutGroup {
+  label: string;
+  workouts: WorkoutWithRow[];
+}
+
+/** Get the Monday of the week containing `dateStr` (ISO yyyy-mm-dd). */
+function getMonday(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  const day = d.getDay(); // 0=Sun … 6=Sat
+  const diff = day === 0 ? 6 : day - 1; // shift so Monday=0
+  d.setDate(d.getDate() - diff);
+  return d.toISOString().slice(0, 10);
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/**
+ * Groups workouts into date buckets: "This Week", "Last Week", then "Month Year".
+ * Preserves the order of workouts within each group.
+ * Empty groups are omitted.
+ */
+export function groupWorkoutsByDate(
+  workouts: WorkoutWithRow[],
+  todayStr: string,
+): WorkoutGroup[] {
+  if (workouts.length === 0) return [];
+
+  const thisMonday = getMonday(todayStr);
+  // Last week's Monday = this Monday - 7 days
+  const lastMondayDate = new Date(thisMonday + 'T00:00:00');
+  lastMondayDate.setDate(lastMondayDate.getDate() - 7);
+  const lastMonday = lastMondayDate.toISOString().slice(0, 10);
+
+  // Ordered map: label → workouts
+  const groups = new Map<string, WorkoutWithRow[]>();
+
+  for (const w of workouts) {
+    const wMonday = getMonday(w.date);
+    let label: string;
+    if (wMonday === thisMonday) {
+      label = 'This Week';
+    } else if (wMonday === lastMonday) {
+      label = 'Last Week';
+    } else {
+      // "Month Year"
+      const d = new Date(w.date + 'T00:00:00');
+      label = `${MONTH_NAMES[d.getMonth()]} ${d.getFullYear()}`;
+    }
+
+    let arr = groups.get(label);
+    if (!arr) {
+      arr = [];
+      groups.set(label, arr);
+    }
+    arr.push(w);
+  }
+
+  return Array.from(groups.entries()).map(([label, wks]) => ({ label, workouts: wks }));
+}
+
+// ── Tag aggregation ──────────────────────────────────────────────────
+
+/**
+ * Returns up to 3 most common muscle-group tags for a workout's exercises.
+ * Excludes equipment tags (BB, DB, FT) and Warmup.
+ */
+export function getWorkoutTags(
+  workoutSets: SetWithRow[],
+  allExercises: ExerciseWithRow[],
+): string[] {
+  if (workoutSets.length === 0) return [];
+
+  // Unique exercise IDs in this workout
+  const exerciseIds = new Set(workoutSets.map(s => s.exercise_id));
+
+  // Count tag occurrences across exercises (not sets)
+  const tagCounts = new Map<string, number>();
+  for (const ex of allExercises) {
+    if (!exerciseIds.has(ex.id)) continue;
+    const tags = ex.tags.split(',').map(t => t.trim()).filter(Boolean);
+    for (const tag of tags) {
+      if (EQUIPMENT_TAGS.has(tag)) continue;
+      tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+    }
+  }
+
+  // Sort by count desc, then alphabetically for ties
+  return Array.from(tagCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 3)
+    .map(([tag]) => tag);
+}

--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -1,10 +1,23 @@
 import { useState } from 'preact/hooks';
 import { navigate } from '../../router/router';
-import { filteredWorkouts, sets } from '../../state/store';
+import { filteredWorkouts, sets, exercises } from '../../state/store';
 import { ActivitiesFilters } from './activities-filters';
+import { groupWorkoutsByDate, getWorkoutTags } from './activities-helpers';
+import { LabelBadge } from '../shared/label-badge';
+
+/** Type-color map for inset box-shadow accent (light theme). */
+const TYPE_COLORS: Record<string, { light: string; dark: string }> = {
+  weight:  { light: '#c53030', dark: '#fca5a5' },
+  stretch: { light: '#2e7d32', dark: '#86efac' },
+  bike:    { light: '#1565c0', dark: '#93c5fd' },
+  yoga:    { light: '#7b1fa2', dark: '#d8b4fe' },
+};
 
 export function ActivitiesScreen() {
   const [showFilters, setShowFilters] = useState(false);
+
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const groups = groupWorkoutsByDate(filteredWorkouts.value, todayStr);
 
   return (
     <div class="screen activities-screen">
@@ -36,32 +49,49 @@ export function ActivitiesScreen() {
           </div>
         ) : (
           <div class="workout-list">
-            {filteredWorkouts.value.map((w) => {
-              const workoutSets = sets.value.filter((s) => s.workout_id === w.id);
-              const exerciseCount = new Set(workoutSets.map((s) => `${s.exercise_id}__${s.exercise_order}`)).size;
-
-              return (
-                <div
-                  key={w.id}
-                  class="workout-card"
-                  onClick={() => navigate(`/history/${w.id}`)}
-                >
-                  <div class="workout-card-left">
-                    <span class="workout-date">{w.date}</span>
-                    {w.time && <span class="workout-time">{w.time}</span>}
-                  </div>
-                  <div class="workout-card-center">
-                    <span class="workout-name">{w.name || w.type}</span>
-                    <span class="workout-meta">
-                      {w.duration_min ? `${w.duration_min} min` : ''}
-                      {w.duration_min && exerciseCount > 0 ? ' · ' : ''}
-                      {exerciseCount > 0 ? `${exerciseCount} exercise${exerciseCount !== 1 ? 's' : ''}` : ''}
-                    </span>
-                  </div>
-                  <span class={`type-badge badge-${w.type}`}>{w.type}</span>
+            {groups.map((group, groupIdx) => (
+              <div key={group.label}>
+                <div class={`date-group-header${groupIdx === 0 ? ' first' : ''}`}>
+                  {group.label}
                 </div>
-              );
-            })}
+                {group.workouts.map((w) => {
+                  const workoutSets = sets.value.filter((s) => s.workout_id === w.id);
+                  const exerciseCount = new Set(workoutSets.map((s) => `${s.exercise_id}__${s.exercise_order}`)).size;
+                  const typeColor = TYPE_COLORS[w.type];
+                  const tags = w.type === 'weight' ? getWorkoutTags(workoutSets, exercises.value) : [];
+
+                  return (
+                    <div
+                      key={w.id}
+                      class={`workout-card workout-card-${w.type}`}
+                      style={typeColor ? { '--type-accent': typeColor.light, '--type-accent-dark': typeColor.dark } as any : undefined}
+                      onClick={() => navigate(`/history/${w.id}`)}
+                    >
+                      <div class="workout-card-left">
+                        <span class="workout-date">{w.date}</span>
+                        {w.time && <span class="workout-time">{w.time}</span>}
+                      </div>
+                      <div class="workout-card-center">
+                        <span class="workout-name">{w.name || w.type}</span>
+                        <span class="workout-meta">
+                          {w.duration_min ? `${w.duration_min} min` : ''}
+                          {w.duration_min && exerciseCount > 0 ? ' · ' : ''}
+                          {exerciseCount > 0 ? `${exerciseCount} exercise${exerciseCount !== 1 ? 's' : ''}` : ''}
+                        </span>
+                        {tags.length > 0 && (
+                          <div class="workout-card-tags">
+                            {tags.map((tag) => (
+                              <LabelBadge key={tag} name={tag} />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <span class={`type-badge badge-${w.type}`}>{w.type}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1541,6 +1541,39 @@ input, select, textarea {
 /* ===== Workout Card Enhancements ===== */
 .workout-card {
   flex-wrap: wrap;
+  box-shadow: inset 4px 0 0 var(--type-accent, transparent);
+}
+
+[data-theme="dark"] .workout-card {
+  box-shadow: inset 4px 0 0 var(--type-accent-dark, transparent);
+}
+
+/* ===== Date Group Headers ===== */
+.date-group-header {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  padding: var(--space-sm) 0;
+  margin-top: var(--space-md);
+}
+
+.date-group-header.first {
+  margin-top: 0;
+}
+
+/* ===== Workout Card Tags ===== */
+.workout-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.workout-card-tags .tag-badge,
+.workout-card-tags .tag-badge-colored {
+  font-size: var(--text-xs);
+  padding: 1px 6px;
 }
 
 .workout-card-left {


### PR DESCRIPTION
Closes #38

## Changes
- **Color-coded left edge**: 4px inset box-shadow on each workout card using the workout type's badge color (weight=red, stretch=green, bike=blue, yoga=purple). Supports both light and dark themes via CSS custom properties.
- **Date group dividers**: Workouts grouped under "This Week", "Last Week", and "Month Year" headers. Lightweight uppercase muted text styling. Empty groups omitted. Works correctly with filters.
- **Muscle group tag pills**: Up to 3 most common muscle group tags shown as compact `LabelBadge` pills below the meta line on weight workout cards. Equipment tags (BB, DB, FT) and Warmup excluded. Uses existing label color system.

## New files
- `activities-helpers.ts` — `groupWorkoutsByDate()` and `getWorkoutTags()` utility functions
- `activities-helpers.test.ts` — 13 tests covering date grouping and tag aggregation

## Test plan
- [x] 194 tests pass (13 new)
- [x] TypeScript clean
- [x] Production build clean