### PR TITLE
feat: month-based date grouping and weekly streak bar (#41)

### DIFF
--- a/frontend/src/components/activities/activities-helpers.test.ts
+++ b/frontend/src/components/activities/activities-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupWorkoutsByDate, getWorkoutTags, EQUIPMENT_TAGS } from './activities-helpers';
+import { groupWorkoutsByDate, getWeekStreak, getWeekWorkoutCount, getWorkoutTags, EQUIPMENT_TAGS } from './activities-helpers';
 import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/types';
 
 function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
@@ -19,82 +19,188 @@ function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
   };
 }
 
-// ── Date grouping ────────────────────────────────────────────────────
+// ── Month-based date grouping ────────────────────────────────────────
 
 describe('groupWorkoutsByDate', () => {
-  // Use 2026-03-15 (Sunday) as "today"
+  // today = 2026-03-15 → "This Month" = March 2026, "Last Month" = February 2026
   const today = '2026-03-15';
 
   it('returns empty array for no workouts', () => {
     expect(groupWorkoutsByDate([], today)).toEqual([]);
   });
 
-  it('groups a workout from today into "This Week"', () => {
-    const workouts = [makeWorkout({ date: '2026-03-15' })];
-    const groups = groupWorkoutsByDate(workouts, today);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('This Week');
-    expect(groups[0].workouts).toHaveLength(1);
-  });
-
-  it('groups workouts from current Mon-Sun into "This Week"', () => {
+  it('groups workouts in the current month into "This Month"', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-03-09' }), // Monday of this week
-      makeWorkout({ id: 'w2', date: '2026-03-15' }), // Sunday (today)
+      makeWorkout({ id: 'w1', date: '2026-03-01' }),
+      makeWorkout({ id: 'w2', date: '2026-03-15' }),
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('This Week');
+    expect(groups[0].label).toBe('This Month');
     expect(groups[0].workouts).toHaveLength(2);
   });
 
-  it('groups previous week into "Last Week"', () => {
+  it('groups workouts in the previous month into "Last Month"', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-03-02' }), // Mon of last week
-      makeWorkout({ id: 'w2', date: '2026-03-08' }), // Sun of last week
+      makeWorkout({ id: 'w1', date: '2026-02-01' }),
+      makeWorkout({ id: 'w2', date: '2026-02-28' }),
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('Last Week');
+    expect(groups[0].label).toBe('Last Month');
     expect(groups[0].workouts).toHaveLength(2);
   });
 
-  it('groups older workouts by month/year', () => {
+  it('groups older workouts by "Month Year"', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-02-15' }),
-      makeWorkout({ id: 'w2', date: '2026-02-20' }),
-      makeWorkout({ id: 'w3', date: '2026-01-05' }),
+      makeWorkout({ id: 'w1', date: '2026-01-15' }),
+      makeWorkout({ id: 'w2', date: '2025-12-20' }),
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(2);
-    expect(groups[0].label).toBe('February 2026');
-    expect(groups[0].workouts).toHaveLength(2);
-    expect(groups[1].label).toBe('January 2026');
-    expect(groups[1].workouts).toHaveLength(1);
+    expect(groups[0].label).toBe('January 2026');
+    expect(groups[1].label).toBe('December 2025');
   });
 
   it('handles mixed groups in correct order', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-03-15' }),  // This Week
-      makeWorkout({ id: 'w2', date: '2026-03-05' }),  // Last Week
-      makeWorkout({ id: 'w3', date: '2026-02-10' }),  // February
-      makeWorkout({ id: 'w4', date: '2026-01-20' }),  // January
+      makeWorkout({ id: 'w1', date: '2026-03-10' }), // This Month
+      makeWorkout({ id: 'w2', date: '2026-02-20' }), // Last Month
+      makeWorkout({ id: 'w3', date: '2026-01-05' }), // January 2026
+      makeWorkout({ id: 'w4', date: '2025-11-10' }), // November 2025
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups.map(g => g.label)).toEqual([
-      'This Week',
-      'Last Week',
-      'February 2026',
+      'This Month',
+      'Last Month',
       'January 2026',
+      'November 2025',
     ]);
   });
 
   it('omits empty groups', () => {
-    // Only a workout in "last week" — no "This Week" group should appear
-    const workouts = [makeWorkout({ date: '2026-03-05' })];
+    const workouts = [makeWorkout({ date: '2026-02-10' })];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('Last Week');
+    expect(groups[0].label).toBe('Last Month');
+  });
+
+  it('no duplicates — month boundary workout falls into exactly one group', () => {
+    // Mar 1 is "This Month", Feb 28 is "Last Month" — no overlap
+    // Input already sorted newest-first (as filteredWorkouts provides)
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-01' }),
+      makeWorkout({ id: 'w2', date: '2026-02-28' }),
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].label).toBe('This Month');
+    expect(groups[0].workouts).toHaveLength(1);
+    expect(groups[0].workouts[0].date).toBe('2026-03-01');
+    expect(groups[1].label).toBe('Last Month');
+    expect(groups[1].workouts).toHaveLength(1);
+    expect(groups[1].workouts[0].date).toBe('2026-02-28');
+  });
+
+  it('handles January today with December as Last Month', () => {
+    const janToday = '2026-01-15';
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-01-10' }),
+      makeWorkout({ id: 'w2', date: '2025-12-20' }),
+    ];
+    const groups = groupWorkoutsByDate(workouts, janToday);
+    expect(groups[0].label).toBe('This Month');
+    expect(groups[1].label).toBe('Last Month');
+  });
+});
+
+// ── Weekly streak ────────────────────────────────────────────────────
+
+describe('getWeekStreak', () => {
+  // 2026-03-15 is a Sunday; Mon of that week = 2026-03-09
+  const today = '2026-03-15';
+
+  it('returns 7 days', () => {
+    expect(getWeekStreak([], today)).toHaveLength(7);
+  });
+
+  it('starts on Monday', () => {
+    const days = getWeekStreak([], today);
+    expect(days[0].date).toBe('2026-03-09'); // Monday
+    expect(days[0].label).toBe('M');
+  });
+
+  it('ends on Sunday', () => {
+    const days = getWeekStreak([], today);
+    expect(days[6].date).toBe('2026-03-15'); // Sunday
+    expect(days[6].label).toBe('S');
+  });
+
+  it('marks today correctly', () => {
+    const days = getWeekStreak([], today);
+    const todayDay = days.find(d => d.isToday);
+    expect(todayDay?.date).toBe('2026-03-15');
+    expect(todayDay?.isToday).toBe(true);
+    expect(days.filter(d => d.isToday)).toHaveLength(1);
+  });
+
+  it('marks days with workouts as hasWorkout=true', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09' }), // Monday
+      makeWorkout({ id: 'w2', date: '2026-03-11' }), // Wednesday
+    ];
+    const days = getWeekStreak(workouts, today);
+    expect(days[0].hasWorkout).toBe(true);  // Mon
+    expect(days[1].hasWorkout).toBe(false); // Tue
+    expect(days[2].hasWorkout).toBe(true);  // Wed
+    expect(days[3].hasWorkout).toBe(false); // Thu
+  });
+
+  it('ignores workouts outside the current week', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-01' }), // last week
+      makeWorkout({ id: 'w2', date: '2026-03-20' }), // next week
+    ];
+    const days = getWeekStreak(workouts, today);
+    expect(days.every(d => !d.hasWorkout)).toBe(true);
+  });
+
+  it('all days empty when no workouts', () => {
+    const days = getWeekStreak([], today);
+    expect(days.every(d => !d.hasWorkout)).toBe(true);
+  });
+
+  it('works correctly when today is Monday', () => {
+    const monday = '2026-03-09';
+    const days = getWeekStreak([], monday);
+    expect(days[0].date).toBe('2026-03-09');
+    expect(days[6].date).toBe('2026-03-15');
+    expect(days[0].isToday).toBe(true);
+  });
+});
+
+describe('getWeekWorkoutCount', () => {
+  const today = '2026-03-15'; // Sunday; week = Mar 9–15
+
+  it('returns 0 for no workouts', () => {
+    expect(getWeekWorkoutCount([], today)).toBe(0);
+  });
+
+  it('counts workouts only within the current week', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09' }),
+      makeWorkout({ id: 'w2', date: '2026-03-11' }),
+      makeWorkout({ id: 'w3', date: '2026-03-01' }), // outside week
+    ];
+    expect(getWeekWorkoutCount(workouts, today)).toBe(2);
+  });
+
+  it('counts multiple workouts on the same day', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', time: '07:00' }),
+      makeWorkout({ id: 'w2', date: '2026-03-09', time: '18:00' }),
+    ];
+    expect(getWeekWorkoutCount(workouts, today)).toBe(2);
   });
 });
 
@@ -117,14 +223,9 @@ describe('getWorkoutTags', () => {
 
   it('returns top 3 most common muscle group tags', () => {
     const tags = getWorkoutTags(workoutSets, exercises);
-    // Push appears on ex1, ex2, ex3 = 3 times
-    // Chest appears on ex1, ex2 = 2 times
-    // Shoulders appears on ex3 = 1 time
-    // Core appears on ex4 = 1 time
     expect(tags).toHaveLength(3);
-    expect(tags[0]).toBe('Push'); // 3 occurrences
-    expect(tags[1]).toBe('Chest'); // 2 occurrences
-    // Third could be Shoulders or Core (both 1); alphabetical tiebreak
+    expect(tags[0]).toBe('Push');
+    expect(tags[1]).toBe('Chest');
     expect(['Core', 'Shoulders']).toContain(tags[2]);
   });
 
@@ -156,8 +257,7 @@ describe('getWorkoutTags', () => {
     const singleSet: SetWithRow[] = [
       { workout_id: 'w1', exercise_id: 'ex4', exercise_name: 'Ab Wheel', section: 'burnout', exercise_order: 1, set_number: 1, planned_reps: '', weight: '', reps: '10', effort: '', notes: '', sheetRow: 2 },
     ];
-    const tags = getWorkoutTags(singleSet, singleEx);
-    expect(tags).toEqual(['Core']);
+    expect(getWorkoutTags(singleSet, singleEx)).toEqual(['Core']);
   });
 
   it('excludes Warmup tag', () => {

--- a/frontend/src/components/activities/activities-helpers.ts
+++ b/frontend/src/components/activities/activities-helpers.ts
@@ -3,20 +3,11 @@ import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/type
 // ── Equipment / non-muscle tags to exclude from card pills ───────────
 export const EQUIPMENT_TAGS = new Set(['BB', 'DB', 'FT', 'Warmup']);
 
-// ── Date grouping ────────────────────────────────────────────────────
+// ── Date grouping (month-based) ──────────────────────────────────────
 
 export interface WorkoutGroup {
   label: string;
   workouts: WorkoutWithRow[];
-}
-
-/** Get the Monday of the week containing `dateStr` (ISO yyyy-mm-dd). */
-function getMonday(dateStr: string): string {
-  const d = new Date(dateStr + 'T00:00:00');
-  const day = d.getDay(); // 0=Sun … 6=Sat
-  const diff = day === 0 ? 6 : day - 1; // shift so Monday=0
-  d.setDate(d.getDate() - diff);
-  return d.toISOString().slice(0, 10);
 }
 
 const MONTH_NAMES = [
@@ -25,9 +16,9 @@ const MONTH_NAMES = [
 ];
 
 /**
- * Groups workouts into date buckets: "This Week", "Last Week", then "Month Year".
- * Preserves the order of workouts within each group.
- * Empty groups are omitted.
+ * Groups workouts into calendar-month buckets: "This Month", "Last Month",
+ * then "Month Year" for older entries. Each workout appears in exactly one group.
+ * Preserves the order of workouts within each group. Empty groups are omitted.
  */
 export function groupWorkoutsByDate(
   workouts: WorkoutWithRow[],
@@ -35,26 +26,30 @@ export function groupWorkoutsByDate(
 ): WorkoutGroup[] {
   if (workouts.length === 0) return [];
 
-  const thisMonday = getMonday(todayStr);
-  // Last week's Monday = this Monday - 7 days
-  const lastMondayDate = new Date(thisMonday + 'T00:00:00');
-  lastMondayDate.setDate(lastMondayDate.getDate() - 7);
-  const lastMonday = lastMondayDate.toISOString().slice(0, 10);
+  const today = new Date(todayStr + 'T00:00:00');
+  const thisYear = today.getFullYear();
+  const thisMonth = today.getMonth();
 
-  // Ordered map: label → workouts
+  const lastMonthDate = new Date(today);
+  lastMonthDate.setDate(1);
+  lastMonthDate.setMonth(lastMonthDate.getMonth() - 1);
+  const lastYear = lastMonthDate.getFullYear();
+  const lastMonth = lastMonthDate.getMonth();
+
   const groups = new Map<string, WorkoutWithRow[]>();
 
   for (const w of workouts) {
-    const wMonday = getMonday(w.date);
+    const d = new Date(w.date + 'T00:00:00');
+    const wYear = d.getFullYear();
+    const wMonth = d.getMonth();
+
     let label: string;
-    if (wMonday === thisMonday) {
-      label = 'This Week';
-    } else if (wMonday === lastMonday) {
-      label = 'Last Week';
+    if (wYear === thisYear && wMonth === thisMonth) {
+      label = 'This Month';
+    } else if (wYear === lastYear && wMonth === lastMonth) {
+      label = 'Last Month';
     } else {
-      // "Month Year"
-      const d = new Date(w.date + 'T00:00:00');
-      label = `${MONTH_NAMES[d.getMonth()]} ${d.getFullYear()}`;
+      label = `${MONTH_NAMES[wMonth]} ${wYear}`;
     }
 
     let arr = groups.get(label);
@@ -66,6 +61,61 @@ export function groupWorkoutsByDate(
   }
 
   return Array.from(groups.entries()).map(([label, wks]) => ({ label, workouts: wks }));
+}
+
+// ── Weekly streak ────────────────────────────────────────────────────
+
+export interface WeekDay {
+  label: string;  // 'M' | 'T' | 'W' | 'T' | 'F' | 'S' | 'S'
+  date: string;   // ISO yyyy-mm-dd
+  hasWorkout: boolean;
+  isToday: boolean;
+}
+
+const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+/**
+ * Returns the Mon–Sun week days for the week containing `todayStr`,
+ * with `hasWorkout` true for days that have at least one workout.
+ * Reads from all workouts (unfiltered).
+ */
+export function getWeekStreak(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): WeekDay[] {
+  const today = new Date(todayStr + 'T00:00:00');
+  const day = today.getDay(); // 0=Sun…6=Sat
+  const diffToMonday = day === 0 ? 6 : day - 1;
+
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - diffToMonday);
+
+  // Build set of workout dates this week for fast lookup
+  const workoutDates = new Set(allWorkouts.map(w => w.date));
+
+  return DAY_LABELS.map((label, i) => {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    const dateStr = d.toISOString().slice(0, 10);
+    return {
+      label,
+      date: dateStr,
+      hasWorkout: workoutDates.has(dateStr),
+      isToday: dateStr === todayStr,
+    };
+  });
+}
+
+/**
+ * Returns the count of workouts in the Mon–Sun week containing `todayStr`.
+ */
+export function getWeekWorkoutCount(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): number {
+  const days = getWeekStreak(allWorkouts, todayStr);
+  const weekDates = new Set(days.map(d => d.date));
+  return allWorkouts.filter(w => weekDates.has(w.date)).length;
 }
 
 // ── Tag aggregation ──────────────────────────────────────────────────

--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'preact/hooks';
 import { navigate } from '../../router/router';
-import { filteredWorkouts, sets, exercises } from '../../state/store';
+import { filteredWorkouts, sets, exercises, workouts } from '../../state/store';
 import { ActivitiesFilters } from './activities-filters';
-import { groupWorkoutsByDate, getWorkoutTags } from './activities-helpers';
+import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount } from './activities-helpers';
 import { LabelBadge } from '../shared/label-badge';
 
 /** Type-color map for inset box-shadow accent (light theme). */
@@ -18,6 +18,8 @@ export function ActivitiesScreen() {
 
   const todayStr = new Date().toISOString().slice(0, 10);
   const groups = groupWorkoutsByDate(filteredWorkouts.value, todayStr);
+  const weekDays = getWeekStreak(workouts.value, todayStr);
+  const weekCount = getWeekWorkoutCount(workouts.value, todayStr);
 
   return (
     <div class="screen activities-screen">
@@ -38,6 +40,28 @@ export function ActivitiesScreen() {
           </button>
         </div>
       </header>
+
+      <div
+        class="week-streak-bar"
+        aria-label={`${weekCount} ${weekCount === 1 ? 'workout' : 'workouts'} this week`}
+      >
+        <div class="week-streak-dots" aria-hidden="true">
+          {weekDays.map((d) => (
+            <div
+              key={d.date}
+              class={`streak-dot${d.hasWorkout ? ' filled' : ''}${d.isToday ? ' today' : ''}`}
+            />
+          ))}
+        </div>
+        <div class="week-streak-labels" aria-hidden="true">
+          {weekDays.map((d) => (
+            <span key={d.date} class={`streak-label${d.isToday ? ' today' : ''}`}>{d.label}</span>
+          ))}
+        </div>
+        <p class="week-streak-count">
+          {weekCount} {weekCount === 1 ? 'workout' : 'workouts'} this week
+        </p>
+      </div>
 
       {showFilters && <ActivitiesFilters />}
 

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1538,6 +1538,65 @@ input, select, textarea {
   padding: var(--space-xs) 0;
 }
 
+/* ===== Week Streak Bar ===== */
+.week-streak-bar {
+  padding: var(--space-md) var(--space-md) var(--space-sm);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.week-streak-dots {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.streak-dot {
+  flex: 1;
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-border);
+  transition: background var(--transition-fast);
+}
+
+.streak-dot.filled {
+  background: var(--color-primary);
+}
+
+.streak-dot.today {
+  box-shadow: 0 0 0 2px var(--color-primary);
+}
+
+.streak-dot.today.filled {
+  box-shadow: none;
+}
+
+.week-streak-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: var(--space-xs);
+}
+
+.streak-label {
+  flex: 1;
+  text-align: center;
+  font-size: 10px;
+  color: var(--color-text-muted);
+  line-height: 1;
+}
+
+.streak-label.today {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.week-streak-count {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
 /* ===== Workout Card Enhancements ===== */
 .workout-card {
   flex-wrap: wrap;


### PR DESCRIPTION
Closes #41

## Changes
- **Month-based grouping**: Replaced week-based date headers ("This Week"/"Last Week") with clean calendar-month buckets — "This Month", "Last Month", and "Month Year" for older. Eliminates the week/month boundary duplicate problem.
- **Weekly streak bar**: New section above the workout list showing Mon–Sun dots (filled = workout that day), day labels, and "N workouts this week" count. Reads from unfiltered `workouts` signal so filters don't affect it.
- **Updated tests**: 25 tests covering month grouping (boundary cases, January/December wraparound, no duplicates), streak days, count, and edge cases.