### PR TITLE
feat: compact icons and login screen icon

### DIFF
--- a/frontend/public/groundwork-icon-192-maskable.svg
+++ b/frontend/public/groundwork-icon-192-maskable.svg
@@ -1,11 +1,9 @@
 <svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
   <rect width="192" height="192" fill="#4f6ef7"/>
   <g transform="translate(48, 48) scale(1.5)">
-    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
-    <rect x="20" y="30" width="24" height="4" fill="white"/>
-    <rect x="14" y="26" width="4" height="12" fill="white"/>
-    <rect x="10" y="28" width="3" height="8" fill="white"/>
-    <rect x="46" y="26" width="4" height="12" fill="white"/>
-    <rect x="51" y="28" width="3" height="8" fill="white"/>
+    <rect x="10" y="42" width="44" height="3" fill="white"/>
+    <rect x="24" y="32" width="16" height="3" fill="white"/>
+    <rect x="19" y="29" width="4" height="9" fill="white"/>
+    <rect x="41" y="29" width="4" height="9" fill="white"/>
   </g>
 </svg>

--- a/frontend/public/groundwork-icon-192.svg
+++ b/frontend/public/groundwork-icon-192.svg
@@ -1,11 +1,9 @@
 <svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
   <rect width="192" height="192" rx="32" fill="#4f6ef7"/>
   <g transform="translate(32, 32) scale(2)">
-    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
-    <rect x="20" y="30" width="24" height="4" fill="white"/>
-    <rect x="14" y="26" width="4" height="12" fill="white"/>
-    <rect x="10" y="28" width="3" height="8" fill="white"/>
-    <rect x="46" y="26" width="4" height="12" fill="white"/>
-    <rect x="51" y="28" width="3" height="8" fill="white"/>
+    <rect x="10" y="42" width="44" height="3" fill="white"/>
+    <rect x="24" y="32" width="16" height="3" fill="white"/>
+    <rect x="19" y="29" width="4" height="9" fill="white"/>
+    <rect x="41" y="29" width="4" height="9" fill="white"/>
   </g>
 </svg>

--- a/frontend/public/groundwork-icon-512-maskable.svg
+++ b/frontend/public/groundwork-icon-512-maskable.svg
@@ -1,11 +1,9 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
   <rect width="512" height="512" fill="#4f6ef7"/>
   <g transform="translate(128, 128) scale(4)">
-    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
-    <rect x="20" y="30" width="24" height="4" fill="white"/>
-    <rect x="14" y="26" width="4" height="12" fill="white"/>
-    <rect x="10" y="28" width="3" height="8" fill="white"/>
-    <rect x="46" y="26" width="4" height="12" fill="white"/>
-    <rect x="51" y="28" width="3" height="8" fill="white"/>
+    <rect x="10" y="42" width="44" height="3" fill="white"/>
+    <rect x="24" y="32" width="16" height="3" fill="white"/>
+    <rect x="19" y="29" width="4" height="9" fill="white"/>
+    <rect x="41" y="29" width="4" height="9" fill="white"/>
   </g>
 </svg>

--- a/frontend/public/groundwork-icon-512.svg
+++ b/frontend/public/groundwork-icon-512.svg
@@ -1,11 +1,9 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
   <rect width="512" height="512" rx="80" fill="#4f6ef7"/>
   <g transform="translate(96, 96) scale(5)">
-    <rect x="6" y="44" width="52" height="4" rx="1" fill="white"/>
-    <rect x="20" y="30" width="24" height="4" fill="white"/>
-    <rect x="14" y="26" width="4" height="12" fill="white"/>
-    <rect x="10" y="28" width="3" height="8" fill="white"/>
-    <rect x="46" y="26" width="4" height="12" fill="white"/>
-    <rect x="51" y="28" width="3" height="8" fill="white"/>
+    <rect x="10" y="42" width="44" height="3" fill="white"/>
+    <rect x="24" y="32" width="16" height="3" fill="white"/>
+    <rect x="19" y="29" width="4" height="9" fill="white"/>
+    <rect x="41" y="29" width="4" height="9" fill="white"/>
   </g>
 </svg>

--- a/frontend/src/auth/login-screen.tsx
+++ b/frontend/src/auth/login-screen.tsx
@@ -5,6 +5,13 @@ export function LoginScreen() {
   return (
     <div class="login-screen">
       <div class="login-card">
+        <img
+          src={`${import.meta.env.BASE_URL}groundwork-favicon.svg`}
+          alt=""
+          class="login-icon"
+          width="64"
+          height="64"
+        />
         <h1>Groundwork</h1>
         <p>Personal Workout Tracker</p>
         <button class="login-btn" onClick={login}>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -166,6 +166,11 @@ input, select, textarea {
   width: 100%;
 }
 
+.login-icon {
+  margin-bottom: var(--space-md);
+  border-radius: var(--radius-md);
+}
+
 .login-card h1 {
   font-size: var(--text-2xl);
   font-weight: 700;


### PR DESCRIPTION
## Summary
- Switch all PWA icons (192, 512, maskable variants) from detailed barbell to simplified compact variant
- Add app icon above title on login screen, matching Hive's login card style
- Add `.login-icon` CSS class with spacing and border radius

## Test plan
- [x] TypeScript compiles without errors
- [x] Login screen shows icon above title
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)