### PR TITLE
fix: align quick-fill row with set rows

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -281,6 +281,9 @@ export function ExerciseRow({
 
       <div class="quick-fill-row">
         <span class="quick-fill-spacer" aria-hidden="true" />
+        {exercise.sets.some(s => s.planned_reps) && (
+          <span class="quick-fill-planned-spacer" aria-hidden="true" />
+        )}
         <div class="set-inputs">
           <input
             id={`quick-fill-wt-${exercise.exercise_id}-${exercise.exercise_order}`}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1293,6 +1293,10 @@ input, select, textarea {
   min-width: 24px;
 }
 
+.quick-fill-planned-spacer {
+  min-width: 32px;
+}
+
 .quick-fill-end-spacer {
   /* set-saved (16px) + gap (4px) + set-remove-btn (24px) */
   min-width: 44px;


### PR DESCRIPTION
## Summary
- Added a planned-reps spacer to the quick-fill header row so `lbs × reps` inputs align with the set rows below when planned reps (e.g. "4-6") are displayed

## Test plan
- [ ] Start a workout from a template with planned reps — verify quick-fill inputs align with set row inputs
- [ ] Start a custom workout (no planned reps) — verify alignment still correct without the spacer

🤖 Generated with [Claude Code](https://claude.com/claude-code)