### PR TITLE
fix: use local dates in weekly streak bar

### DIFF
--- a/frontend/src/api/workouts-api.ts
+++ b/frontend/src/api/workouts-api.ts
@@ -3,6 +3,7 @@
 import type { Workout, WorkoutWithRow, WorkoutSet, SetWithRow, WorkoutType } from './types';
 import { sheetsGet, sheetsAppend, sheetsUpdate, sheetsDeleteRow, getSheetId, withReauth } from './sheets';
 import { isDemo, DEMO_WORKOUTS, DEMO_SETS } from './demo-data';
+import { toLocalDateStr } from '../components/activities/activities-helpers';
 
 // ── Workouts tab (A:J) ──────────────────────────────────────────────
 
@@ -33,7 +34,7 @@ export async function createWorkout(
 ): Promise<Workout> {
   const id = `w_${crypto.randomUUID().slice(0, 8)}`;
   const now = new Date();
-  const date = now.toISOString().slice(0, 10);
+  const date = toLocalDateStr(now);
   const time = now.toTimeString().slice(0, 5);
   const created = now.toISOString();
 

--- a/frontend/src/components/activities/activities-helpers.test.ts
+++ b/frontend/src/components/activities/activities-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupWorkoutsByDate, getWeekStreak, getWeekWorkoutCount, getWorkoutTags, EQUIPMENT_TAGS } from './activities-helpers';
+import { groupWorkoutsByDate, getWeekStreak, getWeekWorkoutCount, getWorkoutTags, EQUIPMENT_TAGS, toLocalDateStr } from './activities-helpers';
 import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/types';
 
 function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
@@ -18,6 +18,27 @@ function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
     ...overrides,
   };
 }
+
+// ── toLocalDateStr ───────────────────────────────────────────────────
+
+describe('toLocalDateStr', () => {
+  it('formats a date as YYYY-MM-DD in local time', () => {
+    const d = new Date(2026, 2, 15); // March 15, 2026 local
+    expect(toLocalDateStr(d)).toBe('2026-03-15');
+  });
+
+  it('pads single-digit month and day', () => {
+    const d = new Date(2026, 0, 5); // January 5
+    expect(toLocalDateStr(d)).toBe('2026-01-05');
+  });
+
+  it('uses local date, not UTC (avoids timezone shift)', () => {
+    // Create a date at local midnight — toISOString would shift this to
+    // the previous day for timezones west of UTC
+    const d = new Date('2026-03-15T00:00:00'); // local midnight
+    expect(toLocalDateStr(d)).toBe('2026-03-15');
+  });
+});
 
 // ── Month-based date grouping ────────────────────────────────────────
 
@@ -176,6 +197,17 @@ describe('getWeekStreak', () => {
     expect(days[0].date).toBe('2026-03-09');
     expect(days[6].date).toBe('2026-03-15');
     expect(days[0].isToday).toBe(true);
+  });
+
+  it('uses local dates (no UTC shift from toISOString)', () => {
+    // All generated dates should match the expected local-time dates,
+    // regardless of the runtime timezone offset
+    const days = getWeekStreak([], '2026-03-15');
+    const dates = days.map(d => d.date);
+    expect(dates).toEqual([
+      '2026-03-09', '2026-03-10', '2026-03-11', '2026-03-12',
+      '2026-03-13', '2026-03-14', '2026-03-15',
+    ]);
   });
 });
 

--- a/frontend/src/components/activities/activities-helpers.ts
+++ b/frontend/src/components/activities/activities-helpers.ts
@@ -74,6 +74,14 @@ export interface WeekDay {
 
 const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 
+/** Format a Date as 'YYYY-MM-DD' in local time (avoids UTC shift from toISOString). */
+export function toLocalDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 /**
  * Returns the Mon–Sun week days for the week containing `todayStr`,
  * with `hasWorkout` true for days that have at least one workout.
@@ -96,7 +104,7 @@ export function getWeekStreak(
   return DAY_LABELS.map((label, i) => {
     const d = new Date(monday);
     d.setDate(monday.getDate() + i);
-    const dateStr = d.toISOString().slice(0, 10);
+    const dateStr = toLocalDateStr(d);
     return {
       label,
       date: dateStr,

--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -2,7 +2,7 @@ import { useState } from 'preact/hooks';
 import { navigate } from '../../router/router';
 import { filteredWorkouts, sets, exercises, workouts } from '../../state/store';
 import { ActivitiesFilters } from './activities-filters';
-import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount } from './activities-helpers';
+import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount, toLocalDateStr } from './activities-helpers';
 import { LabelBadge } from '../shared/label-badge';
 
 /** Type-color map for inset box-shadow accent (light theme). */
@@ -16,7 +16,7 @@ const TYPE_COLORS: Record<string, { light: string; dark: string }> = {
 export function ActivitiesScreen() {
   const [showFilters, setShowFilters] = useState(false);
 
-  const todayStr = new Date().toISOString().slice(0, 10);
+  const todayStr = toLocalDateStr(new Date());
   const groups = groupWorkoutsByDate(filteredWorkouts.value, todayStr);
   const weekDays = getWeekStreak(workouts.value, todayStr);
   const weekCount = getWeekWorkoutCount(workouts.value, todayStr);

--- a/frontend/src/components/workout/last-time-data.test.ts
+++ b/frontend/src/components/workout/last-time-data.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getLastTimeDataFrom, formatLastTimeDate } from './last-time-data';
 import type { SetWithRow, WorkoutWithRow } from '../../api/types';
+import { toLocalDateStr } from '../activities/activities-helpers';
 
 function makeSet(overrides: Partial<SetWithRow> = {}): SetWithRow {
   return {
@@ -159,8 +160,7 @@ describe('formatLastTimeDate', () => {
   });
 
   it('shows "today" for current date', () => {
-    const today = new Date();
-    const dateStr = today.toISOString().slice(0, 10);
+    const dateStr = toLocalDateStr(new Date());
     const result = formatLastTimeDate(dateStr);
     expect(result).toContain('(today)');
   });
@@ -168,7 +168,7 @@ describe('formatLastTimeDate', () => {
   it('shows "yesterday" for one day ago', () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    const dateStr = yesterday.toISOString().slice(0, 10);
+    const dateStr = toLocalDateStr(yesterday);
     const result = formatLastTimeDate(dateStr);
     expect(result).toContain('(yesterday)');
   });

--- a/frontend/src/components/workout/simple-workout.tsx
+++ b/frontend/src/components/workout/simple-workout.tsx
@@ -3,6 +3,7 @@ import type { WorkoutType } from '../../api/types';
 import { useAuth } from '../../auth/auth-context';
 import { startSimpleWorkout } from '../../state/actions';
 import { navigate } from '../../router/router';
+import { toLocalDateStr } from '../activities/activities-helpers';
 
 interface Props {
   workoutType: WorkoutType;
@@ -77,7 +78,7 @@ export function SimpleWorkout({ workoutType, onBack }: Props) {
         <input
           class="form-input"
           type="date"
-          value={now.toISOString().slice(0, 10)}
+          value={toLocalDateStr(now)}
           disabled
         />
       </div>


### PR DESCRIPTION
Closes #45

## Changes
- Added `toLocalDateStr()` helper that formats dates using local timezone instead of UTC
- Fixed `activities-screen.tsx` — `todayStr` was computed in UTC, causing the streak bar to show the wrong week in US timezones on Sunday evenings
- Fixed `activities-helpers.ts` — `getWeekStreak()` generated day dates in UTC, shifting all 7 dates
- Fixed `workouts-api.ts` — `createWorkout()` saved UTC date instead of local date
- Fixed `simple-workout.tsx` — displayed UTC date instead of local date
- Fixed `last-time-data.test.ts` — test helpers had the same UTC bug, causing flaky "today"/"yesterday" test failures

## Test plan
- [x] All 210 existing tests pass
- [x] New `toLocalDateStr` unit tests added (formatting, padding, local vs UTC)
- [x] New `getWeekStreak` test verifies all 7 dates match expected local values
- [x] TypeScript type check clean
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)