### PR TITLE
fix: dark mode date picker icon and number spinner

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -603,6 +603,24 @@ input, select, textarea {
   min-height: 48px;
 }
 
+/* Dark mode: tell browser to render native controls (date picker, etc.) in dark */
+[data-theme="dark"] .form-input,
+[data-theme="dark"] .form-select,
+[data-theme="dark"] .form-textarea {
+  color-scheme: dark;
+}
+
+/* Hide number spinners on form inputs (match set-weight/set-reps pattern) */
+.form-input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.form-input[type="number"]::-webkit-inner-spin-button,
+.form-input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .form-input:focus,
 .form-select:focus,
 .form-textarea:focus {


### PR DESCRIPTION
Closes #51

## Changes
- Added `color-scheme: dark` to `.form-input`, `.form-select`, `.form-textarea` under `[data-theme="dark"]` — tells the browser to render native input controls (calendar icon, dropdowns, etc.) with dark chrome
- Added spinner hiding for `.form-input[type="number"]` using `::-webkit-inner-spin-button`/`::-webkit-outer-spin-button` and `-moz-appearance: textfield` — matches existing pattern used for `.set-weight-input`/`.set-reps-input`