### PR TITLE
feat: show weekly activity minutes in streak bar

### DIFF
--- a/frontend/src/components/activities/activities-helpers.test.ts
+++ b/frontend/src/components/activities/activities-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupWorkoutsByDate, getWeekStreak, getWeekWorkoutCount, getWorkoutTags, EQUIPMENT_TAGS, toLocalDateStr } from './activities-helpers';
+import { groupWorkoutsByDate, getWeekStreak, getWeekWorkoutCount, getWeekTotalMinutes, getWorkoutTags, EQUIPMENT_TAGS, toLocalDateStr } from './activities-helpers';
 import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/types';
 
 function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
@@ -233,6 +233,50 @@ describe('getWeekWorkoutCount', () => {
       makeWorkout({ id: 'w2', date: '2026-03-09', time: '18:00' }),
     ];
     expect(getWeekWorkoutCount(workouts, today)).toBe(2);
+  });
+});
+
+// ── Weekly total minutes ─────────────────────────────────────────────
+
+describe('getWeekTotalMinutes', () => {
+  const today = '2026-03-15'; // Sunday; week = Mar 9–15
+
+  it('AC1: sums all durations when every workout has one', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-11', duration_min: '45' }),
+      makeWorkout({ id: 'w3', date: '2026-03-15', duration_min: '45' }),
+    ];
+    expect(getWeekTotalMinutes(workouts, today)).toBe(150);
+  });
+
+  it('AC2: sums only workouts that have a duration (partial)', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-11', duration_min: '' }),
+      makeWorkout({ id: 'w3', date: '2026-03-13', duration_min: '45' }),
+    ];
+    expect(getWeekTotalMinutes(workouts, today)).toBe(105);
+  });
+
+  it('AC3: returns 0 when no workouts have a duration', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', duration_min: '' }),
+      makeWorkout({ id: 'w2', date: '2026-03-11', duration_min: '' }),
+    ];
+    expect(getWeekTotalMinutes(workouts, today)).toBe(0);
+  });
+
+  it('AC4: returns 0 for no workouts', () => {
+    expect(getWeekTotalMinutes([], today)).toBe(0);
+  });
+
+  it('ignores workouts outside the current week', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-01', duration_min: '90' }), // outside week
+    ];
+    expect(getWeekTotalMinutes(workouts, today)).toBe(60);
   });
 });
 

--- a/frontend/src/components/activities/activities-helpers.ts
+++ b/frontend/src/components/activities/activities-helpers.ts
@@ -126,6 +126,25 @@ export function getWeekWorkoutCount(
   return allWorkouts.filter(w => weekDates.has(w.date)).length;
 }
 
+/**
+ * Returns the total duration in minutes for workouts in the Mon–Sun week
+ * containing `todayStr`. Skips workouts with empty or non-numeric duration_min.
+ */
+export function getWeekTotalMinutes(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): number {
+  const days = getWeekStreak(allWorkouts, todayStr);
+  const weekDates = new Set(days.map(d => d.date));
+  let total = 0;
+  for (const w of allWorkouts) {
+    if (!weekDates.has(w.date)) continue;
+    const mins = parseInt(w.duration_min, 10);
+    if (!isNaN(mins)) total += mins;
+  }
+  return total;
+}
+
 // ── Tag aggregation ──────────────────────────────────────────────────
 
 /**

--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -2,7 +2,7 @@ import { useState } from 'preact/hooks';
 import { navigate } from '../../router/router';
 import { filteredWorkouts, sets, exercises, workouts } from '../../state/store';
 import { ActivitiesFilters } from './activities-filters';
-import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount, toLocalDateStr } from './activities-helpers';
+import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount, getWeekTotalMinutes, toLocalDateStr } from './activities-helpers';
 import { LabelBadge } from '../shared/label-badge';
 
 /** Type-color map for inset box-shadow accent (light theme). */
@@ -20,6 +20,9 @@ export function ActivitiesScreen() {
   const groups = groupWorkoutsByDate(filteredWorkouts.value, todayStr);
   const weekDays = getWeekStreak(workouts.value, todayStr);
   const weekCount = getWeekWorkoutCount(workouts.value, todayStr);
+  const weekMinutes = getWeekTotalMinutes(workouts.value, todayStr);
+  const countText = `${weekCount} ${weekCount === 1 ? 'workout' : 'workouts'} this week`;
+  const ariaLabel = weekMinutes > 0 ? `${countText}, ${weekMinutes} min` : countText;
 
   return (
     <div class="screen activities-screen">
@@ -43,7 +46,7 @@ export function ActivitiesScreen() {
 
       <div
         class="week-streak-bar"
-        aria-label={`${weekCount} ${weekCount === 1 ? 'workout' : 'workouts'} this week`}
+        aria-label={ariaLabel}
       >
         <div class="week-streak-dots" aria-hidden="true">
           {weekDays.map((d) => (
@@ -59,7 +62,7 @@ export function ActivitiesScreen() {
           ))}
         </div>
         <p class="week-streak-count">
-          {weekCount} {weekCount === 1 ? 'workout' : 'workouts'} this week
+          {countText}{weekMinutes > 0 ? ` · ${weekMinutes} min` : ''}
         </p>
       </div>
 


### PR DESCRIPTION
Closes #53

## Changes
- Added `getWeekTotalMinutes()` helper in `activities-helpers.ts` — sums `duration_min` for workouts in the current Mon–Sun week, skipping empty/non-numeric values
- Updated streak bar text to show "X workouts this week · Y min" when total minutes > 0
- Updated `aria-label` on `.week-streak-bar` to include minutes for screen reader accessibility
- Added 5 unit tests covering: all durations, partial durations, no durations, no workouts, outside-week filtering