### PR TITLE
fix: convert finish-workout form to modal overlay

### DIFF
--- a/frontend/src/components/workout/finish-modal.test.ts
+++ b/frontend/src/components/workout/finish-modal.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { h } from 'preact';
+import { FinishWorkoutModal } from './finish-modal';
+
+describe('FinishWorkoutModal', () => {
+  let onNotesChange: ReturnType<typeof vi.fn>;
+  let onFinish: ReturnType<typeof vi.fn>;
+  let onCancel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onNotesChange = vi.fn();
+    onFinish = vi.fn();
+    onCancel = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderModal(overrides: Record<string, unknown> = {}) {
+    const props = {
+      notes: '',
+      onNotesChange,
+      onFinish,
+      onCancel,
+      finishing: false,
+      ...overrides,
+    };
+    return render(h(FinishWorkoutModal as any, props));
+  }
+
+  // AC1: Accessible modal overlay appears on finish
+  describe('AC1: Accessible modal overlay', () => {
+    it('renders with role="dialog" and aria-modal="true"', () => {
+      const { container } = renderModal();
+      const dialog = container.querySelector('[role="dialog"]')!;
+      expect(dialog).toBeTruthy();
+      expect(dialog.getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('has aria-labelledby pointing to the heading', () => {
+      const { container } = renderModal();
+      const dialog = container.querySelector('[role="dialog"]')!;
+      const labelledBy = dialog.getAttribute('aria-labelledby');
+      expect(labelledBy).toBeTruthy();
+      const heading = container.querySelector(`#${labelledBy}`)!;
+      expect(heading).toBeTruthy();
+      expect(heading.textContent).toBe('Finish Workout');
+    });
+
+    it('uses modal-overlay class for fixed positioning', () => {
+      const { container } = renderModal();
+      const overlay = container.querySelector('.modal-overlay');
+      expect(overlay).toBeTruthy();
+    });
+
+    it('auto-focuses the textarea on mount', () => {
+      const { container } = renderModal();
+      const textarea = container.querySelector('textarea');
+      expect(textarea).toBeTruthy();
+      expect(document.activeElement).toBe(textarea);
+    });
+  });
+
+  // AC2: Modal contains notes and correctly-ordered actions
+  describe('AC2: Modal contents and button order', () => {
+    it('contains a "Finish Workout" heading', () => {
+      const { container } = renderModal();
+      const heading = container.querySelector('h2');
+      expect(heading).toBeTruthy();
+      expect(heading!.textContent).toBe('Finish Workout');
+    });
+
+    it('contains a notes textarea with correct placeholder', () => {
+      const { container } = renderModal();
+      const textarea = container.querySelector('textarea');
+      expect(textarea).toBeTruthy();
+      expect(textarea!.getAttribute('placeholder')).toBe('How did it go?');
+    });
+
+    it('contains "Workout Notes (optional)" label', () => {
+      const { container } = renderModal();
+      const label = container.querySelector('.form-label');
+      expect(label).toBeTruthy();
+      expect(label!.textContent).toBe('Workout Notes (optional)');
+    });
+
+    it('has "Save & Finish" button before "Cancel" button', () => {
+      const { container } = renderModal();
+      const buttons = container.querySelectorAll('button');
+      const buttonTexts = Array.from(buttons).map((b) => b.textContent?.trim());
+      const saveIdx = buttonTexts.indexOf('Save & Finish');
+      const cancelIdx = buttonTexts.indexOf('Cancel');
+      expect(saveIdx).toBeGreaterThanOrEqual(0);
+      expect(cancelIdx).toBeGreaterThanOrEqual(0);
+      expect(saveIdx).toBeLessThan(cancelIdx);
+    });
+
+    it('"Save & Finish" is a primary button', () => {
+      const { container } = renderModal();
+      const buttons = Array.from(container.querySelectorAll('button'));
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Finish');
+      expect(saveBtn).toBeTruthy();
+      expect(saveBtn!.classList.contains('btn-primary')).toBe(true);
+    });
+
+    it('"Cancel" is a secondary button', () => {
+      const { container } = renderModal();
+      const buttons = Array.from(container.querySelectorAll('button'));
+      const cancelBtn = buttons.find((b) => b.textContent?.trim() === 'Cancel');
+      expect(cancelBtn).toBeTruthy();
+      expect(cancelBtn!.classList.contains('btn-secondary')).toBe(true);
+    });
+  });
+
+  // AC3: Backdrop click and Escape close the modal (unless saving)
+  describe('AC3: Dismiss behavior', () => {
+    it('calls onCancel when backdrop is clicked', () => {
+      const { container } = renderModal();
+      const overlay = container.querySelector('.modal-overlay')!;
+      fireEvent.click(overlay);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onCancel when modal content is clicked', () => {
+      const { container } = renderModal();
+      const content = container.querySelector('.modal-content')!;
+      fireEvent.click(content);
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('calls onCancel when Escape is pressed', () => {
+      renderModal();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call onCancel on backdrop click while finishing', () => {
+      const { container } = renderModal({ finishing: true });
+      const overlay = container.querySelector('.modal-overlay')!;
+      fireEvent.click(overlay);
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call onCancel on Escape while finishing', () => {
+      renderModal({ finishing: true });
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('disables Cancel button while finishing', () => {
+      const { container } = renderModal({ finishing: true });
+      const buttons = Array.from(container.querySelectorAll('button'));
+      const cancelBtn = buttons.find((b) => b.textContent?.trim() === 'Cancel');
+      expect(cancelBtn).toBeTruthy();
+      expect(cancelBtn!.hasAttribute('disabled')).toBe(true);
+    });
+  });
+
+  // AC4: Save & Finish works from modal
+  describe('AC4: Save & Finish', () => {
+    it('calls onFinish when "Save & Finish" is clicked', () => {
+      const { container } = renderModal();
+      const buttons = Array.from(container.querySelectorAll('button'));
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Finish')!;
+      fireEvent.click(saveBtn);
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows "Saving..." text while finishing', () => {
+      const { container } = renderModal({ finishing: true });
+      const buttons = Array.from(container.querySelectorAll('button'));
+      const savingBtn = buttons.find((b) => b.textContent?.trim() === 'Saving...');
+      expect(savingBtn).toBeTruthy();
+    });
+
+    it('disables "Save & Finish" button while finishing', () => {
+      const { container } = renderModal({ finishing: true });
+      const buttons = Array.from(container.querySelectorAll('button'));
+      const savingBtn = buttons.find((b) => b.textContent?.trim() === 'Saving...');
+      expect(savingBtn).toBeTruthy();
+      expect(savingBtn!.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('passes notes value to textarea', () => {
+      const { container } = renderModal({ notes: 'Great session!' });
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+      expect(textarea.value).toBe('Great session!');
+    });
+
+    it('calls onNotesChange when textarea changes', () => {
+      const { container } = renderModal();
+      const textarea = container.querySelector('textarea')!;
+      fireEvent.input(textarea, { target: { value: 'New notes' } });
+      expect(onNotesChange).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/workout/finish-modal.tsx
+++ b/frontend/src/components/workout/finish-modal.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+interface FinishWorkoutModalProps {
+  notes: string;
+  onNotesChange: (e: Event) => void;
+  onFinish: () => void;
+  onCancel: () => void;
+  finishing: boolean;
+}
+
+const HEADING_ID = 'finish-workout-heading';
+
+export function FinishWorkoutModal({
+  notes,
+  onNotesChange,
+  onFinish,
+  onCancel,
+  finishing,
+}: FinishWorkoutModalProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-focus textarea on mount
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // Escape key handler
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !finishing) {
+        onCancel();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [finishing, onCancel]);
+
+  const handleBackdropClick = (e: MouseEvent) => {
+    if (finishing) return;
+    if ((e.target as HTMLElement).classList.contains('modal-overlay')) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div class="modal-overlay" onClick={handleBackdropClick}>
+      <div
+        class="modal-content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={HEADING_ID}
+        style="max-width: 400px;"
+      >
+        <h2
+          id={HEADING_ID}
+          style="font-size: var(--text-lg); font-weight: 700; margin-bottom: var(--space-md);"
+        >
+          Finish Workout
+        </h2>
+
+        <div class="form-group" style="margin-bottom: var(--space-md);">
+          <label class="form-label">Workout Notes (optional)</label>
+          <textarea
+            ref={textareaRef}
+            class="form-textarea"
+            placeholder="How did it go?"
+            rows={3}
+            value={notes}
+            onInput={onNotesChange}
+          />
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: var(--space-sm);">
+          <button
+            class="btn btn-primary"
+            onClick={onFinish}
+            disabled={finishing}
+            style="width: 100%;"
+          >
+            {finishing ? 'Saving...' : 'Save & Finish'}
+          </button>
+          <button
+            class="btn btn-secondary"
+            onClick={onCancel}
+            disabled={finishing}
+            style="width: 100%;"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -5,6 +5,7 @@ import type { EditSetData } from '../../state/actions';
 import { useAuth } from '../../auth/auth-context';
 import { navigate } from '../../router/router';
 import { AddExerciseModal } from '../exercises/add-exercise-modal';
+import { FinishWorkoutModal } from './finish-modal';
 import { ExerciseRow } from './exercise-row';
 import type { TrackerExercise } from './exercise-row';
 import type { TrackerSet } from './set-row';
@@ -72,6 +73,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
   const [showFinishForm, setShowFinishForm] = useState(false);
   const [reorderAnnouncement, setReorderAnnouncement] = useState('');
   const saveTimers = useRef<Map<string, number>>(new Map());
+  const finishBtnRef = useRef<HTMLButtonElement>(null);
 
   // Edit mode metadata
   const [editDate, setEditDate] = useState(workout?.date || '');
@@ -622,6 +624,7 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
           </button>
         ) : (
           <button
+            ref={finishBtnRef}
             class="btn btn-primary"
             onClick={() => setShowFinishForm(!showFinishForm)}
             disabled={finishing}
@@ -676,37 +679,18 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
         </div>
       )}
 
-      {/* Finish form (non-edit mode only) */}
+      {/* Finish modal (non-edit mode only) */}
       {!editMode && showFinishForm && (
-        <div class="finish-form">
-          <div class="form-group">
-            <label class="form-label">Workout Notes (optional)</label>
-            <textarea
-              class="form-textarea"
-              placeholder="How did it go?"
-              rows={3}
-              value={notes}
-              onInput={(e) => setNotes((e.target as HTMLTextAreaElement).value)}
-            />
-          </div>
-          <div class="finish-form-actions">
-            <button
-              class="btn btn-primary"
-              onClick={handleFinish}
-              disabled={finishing}
-              style={{ flex: 1 }}
-            >
-              {finishing ? 'Saving...' : 'Save & Finish'}
-            </button>
-            <button
-              class="btn btn-secondary"
-              onClick={() => setShowFinishForm(false)}
-              style={{ flex: 1 }}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <FinishWorkoutModal
+          notes={notes}
+          onNotesChange={(e) => setNotes((e.target as HTMLTextAreaElement).value)}
+          onFinish={handleFinish}
+          onCancel={() => {
+            setShowFinishForm(false);
+            finishBtnRef.current?.focus();
+          }}
+          finishing={finishing}
+        />
       )}
 
       {/* aria-live region for reorder announcements */}


### PR DESCRIPTION
Closes #57

## Changes
- Extract new `FinishWorkoutModal` component from inline finish form
- Modal uses existing `.modal-overlay` / `.modal-content` CSS (bottom sheet on mobile, centered on desktop)
- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` for accessibility
- Auto-focus textarea on open; return focus to Finish button on close
- Escape key and backdrop click dismiss (blocked while saving)
- Stacked full-width "Save & Finish" / "Cancel" buttons for mobile touch targets
- 21 new tests covering all 4 acceptance criteria