### PR TITLE
feat: add close button to exercise history panel

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import { SetRow } from './set-row';
 import { LastTimePanel } from './last-time-panel';
 import { ALL_SECTIONS } from './section-management';
@@ -66,6 +66,7 @@ export function ExerciseRow({
   totalExercises,
 }: Props) {
   const isWarmup = exercise.section === 'warmup';
+  const lastTimeToggleRef = useRef<HTMLButtonElement>(null);
   const [showLastTime, setShowLastTime] = useState(false);
   const [flashSets, setFlashSets] = useState(false);
   const [showSectionPicker, setShowSectionPicker] = useState(false);
@@ -244,6 +245,7 @@ export function ExerciseRow({
         </button>
         <div class="tracker-exercise-actions">
           <button
+            ref={lastTimeToggleRef}
             type="button"
             class="last-time-toggle exercise-toolbar-btn"
             onClick={() => setShowLastTime(!showLastTime)}
@@ -275,6 +277,10 @@ export function ExerciseRow({
             onCopyDown(lastTimeSets);
             setFlashSets(true);
             setTimeout(() => setFlashSets(false), 600);
+          }}
+          onClose={() => {
+            setShowLastTime(false);
+            lastTimeToggleRef.current?.focus();
           }}
         />
       )}

--- a/frontend/src/components/workout/last-time-panel.test.ts
+++ b/frontend/src/components/workout/last-time-panel.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { h } from 'preact';
+import { LastTimePanel } from './last-time-panel';
+import * as lastTimeData from './last-time-data';
+import type { SetWithRow } from '../../api/types';
+
+// Mock getLastTimeData
+vi.mock('./last-time-data', async () => {
+  const actual = await vi.importActual('./last-time-data') as Record<string, unknown>;
+  return {
+    ...actual,
+    getLastTimeData: vi.fn(),
+  };
+});
+
+function makeSet(overrides: Partial<SetWithRow> = {}): SetWithRow {
+  return {
+    workout_id: 'w-prev',
+    exercise_id: 'ex1',
+    exercise_name: 'Bench Press',
+    section: 'primary',
+    exercise_order: 1,
+    set_number: 1,
+    planned_reps: '8-10',
+    weight: '135',
+    reps: '10',
+    effort: 'Medium',
+    notes: '',
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+describe('LastTimePanel', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function renderPanel(overrides: Record<string, unknown> = {}) {
+    const props = {
+      exerciseId: 'ex1',
+      exerciseName: 'Bench Press',
+      currentWorkoutId: 'w1',
+      onCopyDown: vi.fn(),
+      onClose: vi.fn(),
+      ...overrides,
+    };
+    return { ...render(h(LastTimePanel as any, props)), props };
+  }
+
+  // AC1: Close button appears in history panel
+  describe('AC1: Close button appears in history panel', () => {
+    it('renders a close button next to Copy Down when data is available', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue({
+        workoutDate: '2026-03-10',
+        sets: [makeSet()],
+      });
+      const { container } = renderPanel();
+      const actionArea = container.querySelector('.last-time-actions');
+      expect(actionArea).toBeTruthy();
+      const buttons = actionArea!.querySelectorAll('button');
+      expect(buttons.length).toBe(2); // Copy Down + Close
+      const closeBtn = container.querySelector('.last-time-close-btn');
+      expect(closeBtn).toBeTruthy();
+      expect(closeBtn!.textContent).toContain('✕');
+    });
+
+    it('close button is visually smaller than Copy Down', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue({
+        workoutDate: '2026-03-10',
+        sets: [makeSet()],
+      });
+      const { container } = renderPanel();
+      const copyBtn = container.querySelector('.copy-down-btn');
+      const closeBtn = container.querySelector('.last-time-close-btn');
+      expect(copyBtn).toBeTruthy();
+      expect(closeBtn).toBeTruthy();
+      // Copy Down should have flex: 1, close button should not
+      // Both should exist in the same flex container
+      const actionArea = container.querySelector('.last-time-actions');
+      expect(actionArea).toBeTruthy();
+      expect(actionArea!.contains(copyBtn!)).toBe(true);
+      expect(actionArea!.contains(closeBtn!)).toBe(true);
+    });
+  });
+
+  // AC2: Close button collapses the panel and returns focus
+  describe('AC2: Close button collapses the panel', () => {
+    it('calls onClose when close button is clicked', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue({
+        workoutDate: '2026-03-10',
+        sets: [makeSet()],
+      });
+      const { container, props } = renderPanel();
+      const closeBtn = container.querySelector('.last-time-close-btn')!;
+      fireEvent.click(closeBtn);
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // AC3: Close button is accessible
+  describe('AC3: Close button is accessible', () => {
+    it('has aria-label="Close history"', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue({
+        workoutDate: '2026-03-10',
+        sets: [makeSet()],
+      });
+      const { container } = renderPanel();
+      const closeBtn = container.querySelector('.last-time-close-btn')!;
+      expect(closeBtn.getAttribute('aria-label')).toBe('Close history');
+    });
+
+    it('is a button element (keyboard-focusable)', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue({
+        workoutDate: '2026-03-10',
+        sets: [makeSet()],
+      });
+      const { container } = renderPanel();
+      const closeBtn = container.querySelector('.last-time-close-btn')!;
+      expect(closeBtn.tagName).toBe('BUTTON');
+    });
+  });
+
+  // AC4: Empty state has no close button
+  describe('AC4: Empty state has no close button', () => {
+    it('does not render close button when no data available', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue(null);
+      const { container } = renderPanel();
+      const closeBtn = container.querySelector('.last-time-close-btn');
+      expect(closeBtn).toBeNull();
+    });
+
+    it('does not render action area when no data available', () => {
+      vi.mocked(lastTimeData.getLastTimeData).mockReturnValue(null);
+      const { container } = renderPanel();
+      const actionArea = container.querySelector('.last-time-actions');
+      expect(actionArea).toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/workout/last-time-panel.tsx
+++ b/frontend/src/components/workout/last-time-panel.tsx
@@ -6,6 +6,7 @@ interface Props {
   exerciseName: string;
   currentWorkoutId: string;
   onCopyDown: (lastTimeSets: SetWithRow[]) => void;
+  onClose: () => void;
 }
 
 function effortClass(effort: string): string {
@@ -13,7 +14,7 @@ function effortClass(effort: string): string {
   return `effort-${effort.toLowerCase()}`;
 }
 
-export function LastTimePanel({ exerciseId, exerciseName, currentWorkoutId, onCopyDown }: Props) {
+export function LastTimePanel({ exerciseId, exerciseName, currentWorkoutId, onCopyDown, onClose }: Props) {
   const data = getLastTimeData(exerciseId, currentWorkoutId);
 
   if (!data) {
@@ -43,13 +44,22 @@ export function LastTimePanel({ exerciseId, exerciseName, currentWorkoutId, onCo
           </div>
         ))}
       </div>
-      <button
-        class="copy-down-btn"
-        onClick={() => onCopyDown(data.sets)}
-        aria-label={`Copy previous workout data for ${exerciseName}`}
-      >
-        Copy Down
-      </button>
+      <div class="last-time-actions">
+        <button
+          class="copy-down-btn"
+          onClick={() => onCopyDown(data.sets)}
+          aria-label={`Copy previous workout data for ${exerciseName}`}
+        >
+          Copy Down
+        </button>
+        <button
+          class="last-time-close-btn"
+          onClick={onClose}
+          aria-label="Close history"
+        >
+          ✕
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1938,11 +1938,15 @@ input, select, textarea {
   border-bottom: none;
 }
 
-.copy-down-btn {
-  display: block;
-  width: 100%;
-  min-height: 44px;
+.last-time-actions {
+  display: flex;
+  gap: var(--space-sm);
   margin-top: var(--space-sm);
+}
+
+.copy-down-btn {
+  flex: 1;
+  min-height: 44px;
   padding: var(--space-xs) var(--space-sm);
   color: var(--color-primary);
   font-weight: 600;
@@ -1957,6 +1961,24 @@ input, select, textarea {
 .copy-down-btn:hover {
   background: var(--color-primary);
   color: var(--color-bg);
+}
+
+.last-time-close-btn {
+  min-width: 44px;
+  min-height: 44px;
+  padding: var(--space-xs);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.last-time-close-btn:hover {
+  background: var(--color-border);
+  color: var(--color-text);
 }
 
 @keyframes copy-down-highlight {


### PR DESCRIPTION
Closes #58

## Changes
- Add `onClose` prop to `LastTimePanel` component
- Render a "✕" close button next to "Copy Down" in a new `.last-time-actions` flex container
- Copy Down gets `flex: 1`, close button is fixed-width ghost style
- Close button returns focus to the history toggle (clock icon) in the toolbar
- `aria-label="Close history"` for screen reader support
- Touch target ≥ 44×44px with `var(--color-text-secondary)` / `var(--color-border)` ghost styling
- Empty state ("No previous data") has no close button
- 7 new tests covering all 4 acceptance criteria