### PR TITLE
feat: save workout for later without starting it

### DIFF
--- a/frontend/src/api/demo-data.ts
+++ b/frontend/src/api/demo-data.ts
@@ -100,10 +100,11 @@ export const DEMO_TEMPLATES: Template[] = groupRows(DEMO_TEMPLATE_ROWS);
 const workoutDate = '2025-01-14';
 
 export const DEMO_WORKOUTS: WorkoutWithRow[] = [
-  { id: 'w_demo001', date: workoutDate, time: '06:30', type: 'weight', name: 'Upper Push A', template_id: 'tpl_demo001', notes: 'Felt strong today', duration_min: '62', created: '2025-01-14T06:30:00.000Z', copied_from: '', sheetRow: 2 },
-  { id: 'w_demo002', date: '2025-01-13', time: '07:00', type: 'stretch', name: 'Morning Stretch', template_id: '', notes: 'Full body stretch, focused on hamstrings and hip flexors', duration_min: '20', created: '2025-01-13T07:00:00.000Z', copied_from: '', sheetRow: 3 },
-  { id: 'w_demo003', date: '2025-01-12', time: '17:30', type: 'bike', name: 'Evening Ride', template_id: '', notes: 'Easy 30 min zone 2 ride on the trainer', duration_min: '30', created: '2025-01-12T17:30:00.000Z', copied_from: '', sheetRow: 4 },
-  { id: 'w_demo004', date: '2025-01-07', time: '06:30', type: 'weight', name: 'Upper Push A', template_id: 'tpl_demo001', notes: 'Good session', duration_min: '58', created: '2025-01-07T06:30:00.000Z', copied_from: '', sheetRow: 5 },
+  { id: 'w_demo001', date: workoutDate, time: '06:30', type: 'weight', name: 'Upper Push A', template_id: 'tpl_demo001', notes: 'Felt strong today', duration_min: '62', created: '2025-01-14T06:30:00.000Z', copied_from: '', status: '', sheetRow: 2 },
+  { id: 'w_demo002', date: '2025-01-13', time: '07:00', type: 'stretch', name: 'Morning Stretch', template_id: '', notes: 'Full body stretch, focused on hamstrings and hip flexors', duration_min: '20', created: '2025-01-13T07:00:00.000Z', copied_from: '', status: '', sheetRow: 3 },
+  { id: 'w_demo003', date: '2025-01-12', time: '17:30', type: 'bike', name: 'Evening Ride', template_id: '', notes: 'Easy 30 min zone 2 ride on the trainer', duration_min: '30', created: '2025-01-12T17:30:00.000Z', copied_from: '', status: '', sheetRow: 4 },
+  { id: 'w_demo004', date: '2025-01-07', time: '06:30', type: 'weight', name: 'Upper Push A', template_id: 'tpl_demo001', notes: 'Good session', duration_min: '58', created: '2025-01-07T06:30:00.000Z', copied_from: '', status: '', sheetRow: 5 },
+  { id: 'w_demo005', date: workoutDate, time: '06:30', type: 'weight', name: 'Upper Pull A', template_id: 'tpl_demo002', notes: '', duration_min: '', created: '2025-01-14T06:30:00.000Z', copied_from: '', status: 'planned', sheetRow: 6 },
 ];
 
 export const DEMO_SETS: SetWithRow[] = [

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -46,6 +46,7 @@ export interface Workout {
   duration_min: string;
   created: string;
   copied_from: string;
+  status: string; // '' = active/complete, 'planned' = saved for later
 }
 export interface WorkoutWithRow extends Workout { sheetRow: number; }
 

--- a/frontend/src/api/workouts-api.ts
+++ b/frontend/src/api/workouts-api.ts
@@ -5,13 +5,13 @@ import { sheetsGet, sheetsAppend, sheetsUpdate, sheetsDeleteRow, getSheetId, wit
 import { isDemo, DEMO_WORKOUTS, DEMO_SETS } from './demo-data';
 import { toLocalDateStr } from '../components/activities/activities-helpers';
 
-// ── Workouts tab (A:J) ──────────────────────────────────────────────
+// ── Workouts tab (A:K) ──────────────────────────────────────────────
 
 export async function fetchWorkouts(token: string): Promise<WorkoutWithRow[]> {
   if (isDemo()) return [...DEMO_WORKOUTS];
 
   return withReauth(token, async (t) => {
-    const rows = await sheetsGet('Workouts!A2:J', t);
+    const rows = await sheetsGet('Workouts!A2:K', t);
     return rows.map((row, i) => ({
       id: row[0] || '',
       date: row[1] || '',
@@ -23,13 +23,14 @@ export async function fetchWorkouts(token: string): Promise<WorkoutWithRow[]> {
       duration_min: row[7] || '',
       created: row[8] || '',
       copied_from: row[9] || '',
+      status: row[10] || '',
       sheetRow: i + 2,
     }));
   });
 }
 
 export async function createWorkout(
-  data: { type: WorkoutType; name: string; template_id?: string; notes?: string; duration_min?: string; copied_from?: string; date?: string },
+  data: { type: WorkoutType; name: string; template_id?: string; notes?: string; duration_min?: string; copied_from?: string; date?: string; status?: string },
   token: string,
 ): Promise<Workout> {
   const id = `w_${crypto.randomUUID().slice(0, 8)}`;
@@ -49,11 +50,12 @@ export async function createWorkout(
     duration_min: data.duration_min || '',
     created,
     copied_from: data.copied_from || '',
+    status: data.status || '',
   };
 
   if (!isDemo()) {
     await withReauth(token, (t) =>
-      sheetsAppend('Workouts!A:J', [[
+      sheetsAppend('Workouts!A:K', [[
         workout.id,
         workout.date,
         workout.time,
@@ -64,6 +66,7 @@ export async function createWorkout(
         workout.duration_min,
         workout.created,
         workout.copied_from,
+        workout.status,
       ]], t),
     );
   }
@@ -79,7 +82,7 @@ export async function updateWorkout(
   if (isDemo()) return;
 
   await withReauth(token, (t) =>
-    sheetsUpdate(`Workouts!A${sheetRow}:J${sheetRow}`, [[
+    sheetsUpdate(`Workouts!A${sheetRow}:K${sheetRow}`, [[
       workout.id,
       workout.date,
       workout.time,
@@ -90,6 +93,7 @@ export async function updateWorkout(
       workout.duration_min,
       workout.created,
       workout.copied_from,
+      workout.status,
     ]], t),
   );
 }

--- a/frontend/src/components/activities/activities-helpers.test.ts
+++ b/frontend/src/components/activities/activities-helpers.test.ts
@@ -14,6 +14,7 @@ function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
     duration_min: '60',
     created: '',
     copied_from: '',
+    status: '',
     sheetRow: 2,
     ...overrides,
   };
@@ -277,6 +278,41 @@ describe('getWeekTotalMinutes', () => {
       makeWorkout({ id: 'w2', date: '2026-03-01', duration_min: '90' }), // outside week
     ];
     expect(getWeekTotalMinutes(workouts, today)).toBe(60);
+  });
+});
+
+// ── Planned workout exclusion (caller responsibility) ────────────────
+// The helpers receive pre-filtered workout lists. These tests confirm
+// that passing only completedWorkouts (status !== 'planned') correctly
+// excludes planned workouts from streak / stats.
+
+describe('week stats exclude planned workouts (via caller filtering)', () => {
+  const today = '2026-03-15'; // week = Mar 9–15
+
+  it('getWeekStreak: planned workouts filtered out by caller are not counted', () => {
+    const planned = makeWorkout({ id: 'w_planned', date: '2026-03-11', status: 'planned' });
+    const completed = makeWorkout({ id: 'w_done', date: '2026-03-09', status: '' });
+
+    // Caller filters out planned before passing
+    const completedOnly = [completed];
+    const days = getWeekStreak(completedOnly, today);
+
+    expect(days[0].hasWorkout).toBe(true);  // Mon Mar 9 — completed
+    expect(days[2].hasWorkout).toBe(false); // Wed Mar 11 — planned was excluded
+  });
+
+  it('getWeekWorkoutCount: planned workouts filtered out by caller are not counted', () => {
+    const planned = makeWorkout({ id: 'w_planned', date: '2026-03-11', status: 'planned' });
+    const completed = makeWorkout({ id: 'w_done', date: '2026-03-09', status: '' });
+    const completedOnly = [completed];
+    expect(getWeekWorkoutCount(completedOnly, today)).toBe(1);
+  });
+
+  it('getWeekTotalMinutes: planned workouts filtered out by caller are not summed', () => {
+    const planned = makeWorkout({ id: 'w_planned', date: '2026-03-11', duration_min: '45', status: 'planned' });
+    const completed = makeWorkout({ id: 'w_done', date: '2026-03-09', duration_min: '60', status: '' });
+    const completedOnly = [completed];
+    expect(getWeekTotalMinutes(completedOnly, today)).toBe(60);
   });
 });
 

--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 import { navigate } from '../../router/router';
-import { filteredWorkouts, sets, exercises, workouts } from '../../state/store';
+import { filteredWorkouts, plannedWorkouts, completedWorkouts, sets, exercises } from '../../state/store';
 import { ActivitiesFilters } from './activities-filters';
 import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount, getWeekTotalMinutes, toLocalDateStr } from './activities-helpers';
 import { LabelBadge } from '../shared/label-badge';
@@ -18,9 +18,11 @@ export function ActivitiesScreen() {
 
   const todayStr = toLocalDateStr(new Date());
   const groups = groupWorkoutsByDate(filteredWorkouts.value, todayStr);
-  const weekDays = getWeekStreak(workouts.value, todayStr);
-  const weekCount = getWeekWorkoutCount(workouts.value, todayStr);
-  const weekMinutes = getWeekTotalMinutes(workouts.value, todayStr);
+  const planned = plannedWorkouts.value;
+  // Week stats use only completed workouts (planned workouts haven't happened yet)
+  const weekDays = getWeekStreak(completedWorkouts.value, todayStr);
+  const weekCount = getWeekWorkoutCount(completedWorkouts.value, todayStr);
+  const weekMinutes = getWeekTotalMinutes(completedWorkouts.value, todayStr);
   const countText = `${weekCount} ${weekCount === 1 ? 'workout' : 'workouts'} this week`;
   const ariaLabel = weekMinutes > 0 ? `${countText}, ${weekMinutes} min` : countText;
 
@@ -67,6 +69,41 @@ export function ActivitiesScreen() {
       </div>
 
       {showFilters && <ActivitiesFilters />}
+
+      {/* Planned workouts section — between streak bar and history */}
+      {planned.length > 0 && (
+        <div class="planned-section">
+          <div class="date-group-header first">Planned</div>
+          {planned.map((w) => {
+            const workoutSets = sets.value.filter((s) => s.workout_id === w.id);
+            const exerciseCount = new Set(workoutSets.map((s) => `${s.exercise_id}__${s.exercise_order}`)).size;
+            const tags = getWorkoutTags(workoutSets, exercises.value);
+
+            return (
+              <div
+                key={w.id}
+                class="workout-card workout-card-planned"
+                onClick={() => navigate(`/history/${w.id}`)}
+              >
+                <div class="workout-card-center">
+                  <span class="workout-name">{w.name || w.type}</span>
+                  <span class="workout-meta">
+                    {exerciseCount > 0 ? `${exerciseCount} exercise${exerciseCount !== 1 ? 's' : ''}` : 'No exercises yet'}
+                  </span>
+                  {tags.length > 0 && (
+                    <div class="workout-card-tags">
+                      {tags.map((tag) => (
+                        <LabelBadge key={tag} name={tag} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <span class="type-badge badge-planned">Planned</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       <div class="screen-body">
         {filteredWorkouts.value.length === 0 ? (

--- a/frontend/src/components/activities/edit-workout.test.ts
+++ b/frontend/src/components/activities/edit-workout.test.ts
@@ -14,6 +14,7 @@ const WORKOUT_WEIGHT: WorkoutWithRow = {
   duration_min: '55',
   created: '2026-03-10T08:00:00.000Z',
   copied_from: '',
+  status: '',
   sheetRow: 2,
 };
 
@@ -28,6 +29,7 @@ const WORKOUT_STRETCH: WorkoutWithRow = {
   duration_min: '15',
   created: '2026-03-11T09:00:00.000Z',
   copied_from: '',
+  status: '',
   sheetRow: 3,
 };
 

--- a/frontend/src/components/activities/workout-detail.tsx
+++ b/frontend/src/components/activities/workout-detail.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
-import { workouts, sets } from '../../state/store';
-import { deleteWorkout, copyWorkout, saveWorkoutAsTemplate } from '../../state/actions';
+import { workouts, sets, activeWorkoutId, showToast } from '../../state/store';
+import { deleteWorkout, copyWorkout, saveWorkoutAsTemplate, startPlannedWorkout } from '../../state/actions';
 import { useAuth } from '../../auth/auth-context';
 import { navigate } from '../../router/router';
 import { ExerciseDetail, groupSetsIntoExercises } from './exercise-detail';
@@ -37,6 +37,7 @@ export function WorkoutDetail({ workoutId }: Props) {
   const workout = workouts.value.find((w) => w.id === workoutId);
   const [expandedIndex, setExpandedIndex] = useState(-1);
   const [deleting, setDeleting] = useState(false);
+  const [startingPlanned, setStartingPlanned] = useState(false);
   const [showLastTime, setShowLastTime] = useState(false);
 
   if (!workout) {
@@ -62,6 +63,24 @@ export function WorkoutDetail({ workoutId }: Props) {
     ? sets.value.filter((s) => s.workout_id === prevWorkout.id)
     : [];
   const prevGroups = prevSets.length > 0 ? groupSetsIntoExercises(prevSets) : [];
+
+  const handleStartPlanned = async () => {
+    if (!token || startingPlanned) return;
+    // Guard: cannot start if another workout is already active
+    if (activeWorkoutId.value) {
+      showToast('Finish your current workout before starting a new one', 'error');
+      return;
+    }
+    setStartingPlanned(true);
+    try {
+      const id = await startPlannedWorkout(workoutId, token);
+      navigate(`/workout/${id}`);
+    } catch {
+      // Error toast shown by action
+    } finally {
+      setStartingPlanned(false);
+    }
+  };
 
   const handleDelete = async () => {
     if (!token) return;
@@ -98,6 +117,8 @@ export function WorkoutDetail({ workoutId }: Props) {
     }
   };
 
+  const isPlanned = workout.status === 'planned';
+
   return (
     <div class="screen workout-detail-screen">
       <div class="template-editor-header">
@@ -108,33 +129,38 @@ export function WorkoutDetail({ workoutId }: Props) {
         >
           ← Back
         </button>
-        <div class="detail-header-actions">
-          {workout.type === 'weight' && exerciseGroups.length > 0 && (
-            <button class="btn btn-secondary btn-sm" onClick={handleSaveAsTemplate}>
-              Save Template
+        {!isPlanned && (
+          <div class="detail-header-actions">
+            {workout.type === 'weight' && exerciseGroups.length > 0 && (
+              <button class="btn btn-secondary btn-sm" onClick={handleSaveAsTemplate}>
+                Save Template
+              </button>
+            )}
+            {workout.type === 'weight' && (
+              <button class="btn btn-secondary btn-sm" onClick={handleCopy}>
+                Copy
+              </button>
+            )}
+            <button
+              class="btn btn-primary btn-sm"
+              onClick={() => navigate(`/history/${workoutId}/edit`)}
+            >
+              Edit
             </button>
-          )}
-          {workout.type === 'weight' && (
-            <button class="btn btn-secondary btn-sm" onClick={handleCopy}>
-              Copy
-            </button>
-          )}
-          <button
-            class="btn btn-primary btn-sm"
-            onClick={() => navigate(`/history/${workoutId}/edit`)}
-          >
-            Edit
-          </button>
-        </div>
+          </div>
+        )}
       </div>
 
       <div class="detail-meta">
         <h2 class="detail-title">{workout.name || workout.type}</h2>
         <div class="detail-info-row">
-          <span class={`type-badge badge-${workout.type}`}>{workout.type}</span>
-          <span class="detail-date">{workout.date}</span>
-          {workout.time && <span class="detail-time">{workout.time}</span>}
-          {workout.duration_min && (
+          {isPlanned
+            ? <span class="type-badge badge-planned">Planned</span>
+            : <span class={`type-badge badge-${workout.type}`}>{workout.type}</span>
+          }
+          {!isPlanned && <span class="detail-date">{workout.date}</span>}
+          {!isPlanned && workout.time && <span class="detail-time">{workout.time}</span>}
+          {!isPlanned && workout.duration_min && (
             <span class="detail-duration">{workout.duration_min} min</span>
           )}
         </div>
@@ -145,6 +171,19 @@ export function WorkoutDetail({ workoutId }: Props) {
           <p class="detail-copied">Copied from a previous workout</p>
         )}
       </div>
+
+      {/* Planned workout: Start Workout as the primary CTA */}
+      {isPlanned && (
+        <div class="planned-detail-start">
+          <button
+            class="btn btn-primary planned-start-btn"
+            onClick={handleStartPlanned}
+            disabled={startingPlanned}
+          >
+            {startingPlanned ? 'Starting…' : 'Start Workout'}
+          </button>
+        </div>
+      )}
 
       {/* Exercise breakdown for weight workouts */}
       {exerciseGroups.length > 0 && (

--- a/frontend/src/components/exercises/exercises-screen.test.ts
+++ b/frontend/src/components/exercises/exercises-screen.test.ts
@@ -202,7 +202,7 @@ const mockSets: SetWithRow[] = [
 ];
 
 const mockWorkouts: WorkoutWithRow[] = [
-  { id: 'w1', date: '2026-03-10', time: '07:00', type: 'weight', name: 'Push A', template_id: '', notes: '', duration_min: '60', created: '2026-03-10T07:00:00.000Z', copied_from: '', sheetRow: 2 },
+  { id: 'w1', date: '2026-03-10', time: '07:00', type: 'weight', name: 'Push A', template_id: '', notes: '', duration_min: '60', created: '2026-03-10T07:00:00.000Z', copied_from: '', status: '', sheetRow: 2 },
 ];
 
 describe('Issue #23 — Exercise card last-workout info', () => {
@@ -230,8 +230,8 @@ describe('Issue #23 — Exercise card last-workout info', () => {
         { workout_id: 'w_new', exercise_id: 'ex1', exercise_name: 'Bench Press', section: 'primary', exercise_order: 1, set_number: 1, planned_reps: '', weight: '185', reps: '8', effort: '', notes: '', sheetRow: 3 },
       ];
       const wkts: WorkoutWithRow[] = [
-        { id: 'w_old', date: '2026-01-01', time: '', type: 'weight', name: '', template_id: '', notes: '', duration_min: '', created: '', copied_from: '', sheetRow: 2 },
-        { id: 'w_new', date: '2026-03-10', time: '', type: 'weight', name: '', template_id: '', notes: '', duration_min: '', created: '', copied_from: '', sheetRow: 3 },
+        { id: 'w_old', date: '2026-01-01', time: '', type: 'weight', name: '', template_id: '', notes: '', duration_min: '', created: '', copied_from: '', status: '', sheetRow: 2 },
+        { id: 'w_new', date: '2026-03-10', time: '', type: 'weight', name: '', template_id: '', notes: '', duration_min: '', created: '', copied_from: '', status: '', sheetRow: 3 },
       ];
       const map = buildLastPerformedMap(setsMulti, wkts);
       expect(map.get('ex1')).toBe('2026-03-10');

--- a/frontend/src/components/workout/last-time-data.test.ts
+++ b/frontend/src/components/workout/last-time-data.test.ts
@@ -33,6 +33,7 @@ function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
     duration_min: '60',
     created: '2026-03-10T07:00:00.000Z',
     copied_from: '',
+    status: '',
     sheetRow: 2,
     ...overrides,
   };
@@ -139,7 +140,7 @@ describe('getLastTimeDataFrom', () => {
       { workout_id: 'w_demo001', exercise_id: 'ex_demo001', exercise_name: 'Bench Press BB', section: 'primary', exercise_order: 3, set_number: 4, planned_reps: '4-6', weight: '185', reps: '4', effort: 'Hard', notes: 'Last rep was a grinder', sheetRow: 7 },
     ];
     const allWorkouts: WorkoutWithRow[] = [
-      { id: 'w_demo001', date: '2025-01-14', time: '06:30', type: 'weight', name: 'Upper Push A', template_id: 'tpl_demo001', notes: '', duration_min: '62', created: '2025-01-14T06:30:00.000Z', copied_from: '', sheetRow: 2 },
+      { id: 'w_demo001', date: '2025-01-14', time: '06:30', type: 'weight', name: 'Upper Push A', template_id: 'tpl_demo001', notes: '', duration_min: '62', created: '2025-01-14T06:30:00.000Z', copied_from: '', status: '', sheetRow: 2 },
     ];
 
     const result = getLastTimeDataFrom('ex_demo001', 'w_new', allSets, allWorkouts);

--- a/frontend/src/components/workout/plan-action-sheet.tsx
+++ b/frontend/src/components/workout/plan-action-sheet.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+interface Props {
+  workoutName: string;
+  isCustom?: boolean;
+  starting: boolean;
+  saving: boolean;
+  onStartNow: () => void;
+  onSaveForLater: () => void;
+  onCancel: () => void;
+}
+
+export function PlanActionSheet({
+  workoutName,
+  isCustom,
+  starting,
+  saving,
+  onStartNow,
+  onSaveForLater,
+  onCancel,
+}: Props) {
+  const titleId = 'plan-action-sheet-title';
+  const firstButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the first button when the sheet opens
+  useEffect(() => {
+    firstButtonRef.current?.focus();
+  }, []);
+
+  // Dismiss on Escape key
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onCancel]);
+
+  const handleBackgroundClick = (e: MouseEvent) => {
+    if ((e.target as HTMLElement).classList.contains('modal-overlay')) {
+      onCancel();
+    }
+  };
+
+  const busy = starting || saving;
+
+  return (
+    <div class="modal-overlay" onClick={handleBackgroundClick}>
+      <div
+        class="modal-content plan-action-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <h2 id={titleId} class="plan-action-sheet-title">
+          {workoutName}
+        </h2>
+
+        {isCustom && (
+          <p class="plan-action-sheet-note">
+            Your exercise list will be empty — you can add exercises when you start.
+          </p>
+        )}
+
+        <div class="plan-action-sheet-actions">
+          <button
+            ref={firstButtonRef}
+            class="btn btn-primary plan-action-sheet-btn"
+            onClick={onStartNow}
+            disabled={busy}
+          >
+            {starting ? 'Starting…' : 'Start Now'}
+          </button>
+          <button
+            class="btn btn-secondary plan-action-sheet-btn"
+            onClick={onSaveForLater}
+            disabled={busy}
+          >
+            {saving ? 'Saving…' : 'Save for Later'}
+          </button>
+          <button
+            class="btn btn-ghost plan-action-sheet-btn"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workout/workout-flow.tsx
+++ b/frontend/src/components/workout/workout-flow.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'preact/hooks';
 import { workouts, activeWorkoutId, activeWorkoutSets, activeWarmupExercises, sets, templates } from '../../state/store';
-import { startWorkout } from '../../state/actions';
+import { startWorkout, saveWorkoutForLater } from '../../state/actions';
 import { useAuth } from '../../auth/auth-context';
 import { navigate } from '../../router/router';
 import { TypeSelector } from './type-selector';
 import { TemplatePicker } from './template-picker';
 import { WorkoutTracker } from './workout-tracker';
 import { SimpleWorkout } from './simple-workout';
+import { PlanActionSheet } from './plan-action-sheet';
 import type { WorkoutType } from '../../api/types';
 
 type FlowStep = 'type' | 'template' | 'tracker' | 'simple';
@@ -22,6 +23,12 @@ export function WorkoutFlow({ workoutId }: Props) {
   const [activeId, setActiveId] = useState<string | null>(workoutId || null);
   const [workoutName, setWorkoutName] = useState('');
   const [starting, setStarting] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Action sheet state
+  const [showActionSheet, setShowActionSheet] = useState(false);
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(null);
+  const [pendingIsCustom, setPendingIsCustom] = useState(false);
 
   // If resuming an existing workout, jump to the correct step
   useEffect(() => {
@@ -74,21 +81,49 @@ export function WorkoutFlow({ workoutId }: Props) {
     }
   };
 
-  const handleTemplateSelect = async (templateId: string) => {
+  // Called when the user taps a template card — show the action sheet
+  const handleTemplateCardTap = (templateId: string) => {
+    setPendingTemplateId(templateId);
+    setPendingIsCustom(false);
+    setShowActionSheet(true);
+  };
+
+  // Called when the user taps "Build Custom" — show the action sheet
+  const handleBuildCustomTap = () => {
+    setPendingTemplateId(null);
+    setPendingIsCustom(true);
+    setShowActionSheet(true);
+  };
+
+  const handleCancelActionSheet = () => {
+    setShowActionSheet(false);
+    setPendingTemplateId(null);
+    setPendingIsCustom(false);
+  };
+
+  // "Start Now" path
+  const handleStartNow = async () => {
     if (!token || starting) return;
     setStarting(true);
     try {
-      const tpl = templates.value.find((t) => t.id === templateId);
-      const name = tpl?.name || 'Workout';
-      const id = await startWorkout({
-        type: 'weight',
-        name,
-        template_id: templateId,
-      }, token);
+      let name: string;
+      let id: string;
+
+      if (pendingIsCustom) {
+        name = 'Custom Workout';
+        id = await startWorkout({ type: 'weight', name }, token);
+      } else if (pendingTemplateId) {
+        const tpl = templates.value.find((t) => t.id === pendingTemplateId);
+        name = tpl?.name || 'Workout';
+        id = await startWorkout({ type: 'weight', name, template_id: pendingTemplateId }, token);
+      } else {
+        return;
+      }
+
+      setShowActionSheet(false);
       setActiveId(id);
       setWorkoutName(name);
       setStep('tracker');
-      // Update URL without triggering re-render loop
       window.location.hash = `#/workout/${id}`;
     } catch {
       // Error toast shown by action
@@ -97,31 +132,44 @@ export function WorkoutFlow({ workoutId }: Props) {
     }
   };
 
-  const handleBuildCustom = async () => {
-    if (!token || starting) return;
-    setStarting(true);
+  // "Save for Later" path
+  const handleSaveForLater = async () => {
+    if (!token || saving) return;
+    setSaving(true);
     try {
-      const name = 'Custom Workout';
-      const id = await startWorkout({
-        type: 'weight',
-        name,
-      }, token);
-      setActiveId(id);
-      setWorkoutName(name);
-      setStep('tracker');
-      window.location.hash = `#/workout/${id}`;
+      if (pendingIsCustom) {
+        await saveWorkoutForLater({ type: 'weight', name: 'Custom Workout' }, token);
+      } else if (pendingTemplateId) {
+        const tpl = templates.value.find((t) => t.id === pendingTemplateId);
+        const name = tpl?.name || 'Workout';
+        await saveWorkoutForLater({ type: 'weight', name, template_id: pendingTemplateId }, token);
+      } else {
+        return;
+      }
+      setShowActionSheet(false);
+      navigate('/');
     } catch {
       // Error toast shown by action
     } finally {
-      setStarting(false);
+      setSaving(false);
     }
   };
 
-  if (starting) {
+  // Pending workout name for the action sheet title
+  const getPendingName = () => {
+    if (pendingIsCustom) return 'Custom Workout';
+    if (pendingTemplateId) {
+      const tpl = templates.value.find((t) => t.id === pendingTemplateId);
+      return tpl?.name || 'Workout';
+    }
+    return 'Workout';
+  };
+
+  if (starting || saving) {
     return (
       <div class="loading-screen">
         <div class="spinner" />
-        <p>Starting workout...</p>
+        <p>{saving ? 'Saving…' : 'Starting workout…'}</p>
       </div>
     );
   }
@@ -131,11 +179,24 @@ export function WorkoutFlow({ workoutId }: Props) {
       return <TypeSelector onSelect={handleTypeSelect} />;
     case 'template':
       return (
-        <TemplatePicker
-          onSelectTemplate={handleTemplateSelect}
-          onBuildCustom={handleBuildCustom}
-          onBack={() => setStep('type')}
-        />
+        <>
+          <TemplatePicker
+            onSelectTemplate={handleTemplateCardTap}
+            onBuildCustom={handleBuildCustomTap}
+            onBack={() => setStep('type')}
+          />
+          {showActionSheet && (
+            <PlanActionSheet
+              workoutName={getPendingName()}
+              isCustom={pendingIsCustom}
+              starting={starting}
+              saving={saving}
+              onStartNow={handleStartNow}
+              onSaveForLater={handleSaveForLater}
+              onCancel={handleCancelActionSheet}
+            />
+          )}
+        </>
       );
     case 'tracker':
       return activeId ? (

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -455,6 +455,91 @@ input, select, textarea {
   color: #d7ccc8;
 }
 
+.badge-planned {
+  background: #ede9fe;
+  color: #4c1d95;
+  border: 1.5px dashed #7c3aed;
+}
+
+[data-theme="dark"] .badge-planned {
+  background: #1e1a33;
+  color: #c4b5fd;
+  border-color: #7c3aed;
+}
+
+/* ===== Planned Section (Activities screen) ===== */
+.planned-section {
+  padding: 0 var(--space-md);
+}
+
+.workout-card-planned {
+  border: 1.5px dashed var(--color-border);
+  background: var(--color-surface-raised);
+}
+
+/* ===== Planned Workout Detail ===== */
+.planned-detail-start {
+  padding: var(--space-md) var(--space-md) 0;
+}
+
+.planned-start-btn {
+  width: 100%;
+}
+
+/* ===== Plan Action Sheet ===== */
+.plan-action-sheet {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.plan-action-sheet-title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  margin-bottom: var(--space-xs);
+}
+
+.plan-action-sheet-note {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-sm);
+}
+
+.plan-action-sheet-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.plan-action-sheet-btn {
+  width: 100%;
+}
+
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: var(--text-base);
+  min-height: 48px;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
+}
+
+.btn-ghost:hover {
+  background: var(--color-surface-raised);
+}
+
+.btn-ghost:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ===== Section Badges ===== */
 .section-badge {
   display: inline-flex;

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -4,6 +4,7 @@ import { fetchExercises, createExercise, updateExercise as updateExerciseApi, de
 import { fetchLabels, createLabel as createLabelApi, updateLabel as updateLabelApi, deleteLabel as deleteLabelApi, appendLabels } from '../api/labels-api';
 import { fetchTemplateRows, groupTemplateRows, createTemplate as createTemplateApi, updateTemplate as updateTemplateApi, deleteTemplate as deleteTemplateApi, updateExerciseNameInTemplates } from '../api/templates-api';
 import { fetchWorkouts, fetchSets, createWorkout as createWorkoutApi, updateWorkout as updateWorkoutApi, deleteWorkoutRows, appendSet as appendSetApi, appendSets as appendSetsApi, updateSet as updateSetApi, deleteSetRow, updateExerciseNameInSets } from '../api/workouts-api';
+import { toLocalDateStr } from '../components/activities/activities-helpers';
 import { colorKeyFromName } from '../api/label-colors';
 import type { TemplateExerciseInput } from '../api/templates-api';
 import type { ExerciseWithRow, LabelWithRow, TemplateRowWithRow, WorkoutType, WorkoutSet, SetWithRow } from '../api/types';
@@ -247,6 +248,87 @@ export async function removeExercise(
 }
 
 // ── Workouts ─────────────────────────────────────────────────────────
+
+export async function saveWorkoutForLater(
+  data: { type: WorkoutType; name: string; template_id?: string },
+  token: string,
+): Promise<void> {
+  try {
+    const workout = await createWorkoutApi({
+      type: data.type,
+      name: data.name,
+      template_id: data.template_id,
+      status: 'planned',
+    }, token);
+
+    const withRow = { ...workout, sheetRow: workouts.value.length + 2 };
+    workouts.value = [withRow, ...workouts.value];
+
+    // Pre-populate set structure from template (same as startWorkout)
+    if (data.template_id) {
+      await prepopulateSetsFromTemplate(workout.id, data.template_id, token);
+    } else {
+      activeWorkoutSets.value = [];
+      activeWarmupExercises.value = [];
+    }
+
+    showToast('Workout saved for later', 'success');
+  } catch (err) {
+    if (isReauthFailure(err)) throw err;
+    showToast('Failed to save workout', 'error');
+    throw err;
+  }
+}
+
+export async function startPlannedWorkout(
+  workoutId: string,
+  token: string,
+): Promise<string> {
+  try {
+    const workout = workouts.value.find((w) => w.id === workoutId);
+    if (!workout) throw new Error('Workout not found');
+
+    const now = new Date();
+    const date = toLocalDateStr(now);
+    const time = now.toTimeString().slice(0, 5);
+
+    const updated = { ...workout, status: '', date, time };
+
+    await updateWorkoutApi(workout.sheetRow, updated, token);
+    workouts.value = workouts.value.map((w) =>
+      w.id === workoutId ? { ...updated, sheetRow: workout.sheetRow } : w,
+    );
+
+    activeWorkoutId.value = workoutId;
+    activeWorkoutSets.value = sets.value.filter((s) => s.workout_id === workoutId);
+
+    // Restore warmup exercises from template if applicable
+    if (workout.template_id) {
+      const tpl = templates.value.find((t) => t.id === workout.template_id);
+      if (tpl) {
+        const workoutSets = activeWorkoutSets.value;
+        activeWarmupExercises.value = tpl.exercises
+          .filter((ex) => ex.section === 'warmup')
+          .filter((ex) => !workoutSets.some(
+            (s) => s.exercise_id === ex.exercise_id && s.exercise_order === ex.order && s.section === 'warmup',
+          ))
+          .map((ex) => ({
+            exercise_id: ex.exercise_id,
+            exercise_name: ex.exercise_name,
+            exercise_order: ex.order,
+          }));
+      }
+    } else {
+      activeWarmupExercises.value = [];
+    }
+
+    return workoutId;
+  } catch (err) {
+    if (isReauthFailure(err)) throw err;
+    showToast('Failed to start workout', 'error');
+    throw err;
+  }
+}
 
 export async function startWorkout(
   data: { type: WorkoutType; name: string; template_id?: string; copied_from?: string },

--- a/frontend/src/state/store.test.ts
+++ b/frontend/src/state/store.test.ts
@@ -8,6 +8,8 @@ import {
   filterType,
   filterTags,
   filteredWorkouts,
+  plannedWorkouts,
+  completedWorkouts,
   allTags,
   getLabelByName,
   labelUsageCount,
@@ -40,6 +42,7 @@ function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
     duration_min: '60',
     created: '2025-01-15T08:00:00.000Z',
     copied_from: '',
+    status: '',
     sheetRow: 2,
     ...overrides,
   };
@@ -227,6 +230,75 @@ describe('filteredWorkouts', () => {
 
   it('returns empty array when no workouts exist', () => {
     expect(filteredWorkouts.value).toEqual([]);
+  });
+
+  it('excludes planned workouts from the history list', () => {
+    workouts.value = [
+      makeWorkout({ id: 'w1', date: '2025-01-15', status: '' }),
+      makeWorkout({ id: 'w2', date: '2025-01-14', status: 'planned' }),
+    ];
+
+    const result = filteredWorkouts.value;
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('w1');
+  });
+
+  it('returns empty when all workouts are planned', () => {
+    workouts.value = [
+      makeWorkout({ id: 'w1', status: 'planned' }),
+      makeWorkout({ id: 'w2', status: 'planned' }),
+    ];
+
+    expect(filteredWorkouts.value).toHaveLength(0);
+  });
+});
+
+describe('plannedWorkouts', () => {
+  beforeEach(resetSignals);
+
+  it('returns only workouts with status="planned"', () => {
+    workouts.value = [
+      makeWorkout({ id: 'w1', status: '' }),
+      makeWorkout({ id: 'w2', status: 'planned' }),
+      makeWorkout({ id: 'w3', status: 'planned' }),
+    ];
+
+    expect(plannedWorkouts.value).toHaveLength(2);
+    expect(plannedWorkouts.value.every(w => w.status === 'planned')).toBe(true);
+  });
+
+  it('returns empty when no planned workouts exist', () => {
+    workouts.value = [makeWorkout({ status: '' })];
+    expect(plannedWorkouts.value).toHaveLength(0);
+  });
+
+  it('returns empty when no workouts exist', () => {
+    expect(plannedWorkouts.value).toEqual([]);
+  });
+});
+
+describe('completedWorkouts', () => {
+  beforeEach(resetSignals);
+
+  it('returns only workouts without status="planned"', () => {
+    workouts.value = [
+      makeWorkout({ id: 'w1', status: '' }),
+      makeWorkout({ id: 'w2', status: 'planned' }),
+      makeWorkout({ id: 'w3', type: 'stretch', status: '' }),
+    ];
+
+    expect(completedWorkouts.value).toHaveLength(2);
+    expect(completedWorkouts.value.map(w => w.id)).toContain('w1');
+    expect(completedWorkouts.value.map(w => w.id)).toContain('w3');
+  });
+
+  it('returns all workouts when none are planned', () => {
+    workouts.value = [
+      makeWorkout({ id: 'w1', status: '' }),
+      makeWorkout({ id: 'w2', status: '' }),
+    ];
+
+    expect(completedWorkouts.value).toHaveLength(2);
   });
 });
 

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -24,9 +24,20 @@ export const isEditMode = signal(false);
 export const filterType = signal<WorkoutType | null>(null);
 export const filterTags = signal<string[]>([]);
 
+// Planned workouts (status === 'planned') — shown in dedicated section, excluded from history/stats
+export const plannedWorkouts = computed(() =>
+  workouts.value.filter(w => w.status === 'planned'),
+);
+
+// Completed workouts (status !== 'planned') — used for week streak / stats
+export const completedWorkouts = computed(() =>
+  workouts.value.filter(w => w.status !== 'planned'),
+);
+
 // Derived signals
 export const filteredWorkouts = computed(() => {
-  let result = workouts.value;
+  // Exclude planned workouts — they live in the planned section, not the history list
+  let result = workouts.value.filter(w => w.status !== 'planned');
   if (filterType.value) {
     result = result.filter(w => w.type === filterType.value);
   }


### PR DESCRIPTION
Closes #66

## Changes

### Data model
- `Workout.status` field added (`''` = active/complete, `'planned'` = saved for later)
- Workouts sheet range extended to `A:K` — column K is `status`; existing rows read `''` for missing values (no migration needed)

### New action sheet flow
- Tapping a template card or "Build Custom" now opens `PlanActionSheet` — an accessible modal (`role="dialog"`, `aria-labelledby`, focus-on-open, Escape-dismiss) with **Start Now** (primary) and **Save for Later** (secondary) actions, both ≥ 48px
- "Build Custom" variant includes a note that the exercise list starts empty
- Loading spinner label is context-aware: "Starting workout…" vs "Saving…"

### Planned section on Activities
- `plannedWorkouts` and `completedWorkouts` computed signals added to store
- `filteredWorkouts` now excludes planned workouts (history list only shows completed)
- Planned section rendered between the week streak bar and the history list
- Each planned card shows a **Planned** text badge (dashed border, distinct color — not color-only) replacing the type badge
- Week streak dots, workout count, and total minutes use `completedWorkouts` only

### Planned workout detail
- `WorkoutDetail` detects `status === 'planned'` and renders a dedicated planned view
- **Start Workout** is the full-width primary CTA
- Concurrent-workout guard: if `activeWorkoutId` is already set, shows toast "Finish your current workout before starting a new one"
- Starting clears `status`, updates date/time to now, navigates to the active tracker
- Delete button remains available for discarding a plan

### Tests
- 10 new test cases: `plannedWorkouts`, `completedWorkouts`, `filteredWorkouts` exclusion, week-stats exclusion via caller filtering
- `status: ''` added to all `makeWorkout` fixtures across 5 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)