### PR TITLE
feat: weekly sections and expanded stats on Activities screen

### DIFF
--- a/frontend/src/components/activities/activities-helpers.test.ts
+++ b/frontend/src/components/activities/activities-helpers.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { groupWorkoutsByDate, getWeekStreak, getWeekWorkoutCount, getWeekTotalMinutes, getWorkoutTags, EQUIPMENT_TAGS, toLocalDateStr } from './activities-helpers';
+import {
+  groupWorkoutsByDate,
+  getWeekStreak,
+  getWeekWorkoutCount,
+  getWeekTotalMinutes,
+  getLastWeekWorkoutCount,
+  getLastWeekTotalMinutes,
+  getMonthWorkoutCount,
+  getMonthTotalMinutes,
+  getWorkoutTags,
+  EQUIPMENT_TAGS,
+  toLocalDateStr,
+} from './activities-helpers';
 import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/types';
 
 function makeWorkout(overrides: Partial<WorkoutWithRow> = {}): WorkoutWithRow {
@@ -34,105 +46,129 @@ describe('toLocalDateStr', () => {
   });
 
   it('uses local date, not UTC (avoids timezone shift)', () => {
-    // Create a date at local midnight — toISOString would shift this to
-    // the previous day for timezones west of UTC
     const d = new Date('2026-03-15T00:00:00'); // local midnight
     expect(toLocalDateStr(d)).toBe('2026-03-15');
   });
 });
 
-// ── Month-based date grouping ────────────────────────────────────────
+// ── Weekly section grouping ──────────────────────────────────────────
+// today = '2026-03-18' (Wednesday)
+// This week: 2026-03-16 (Mon) – 2026-03-22 (Sun)
+// Last week: 2026-03-09 (Mon) – 2026-03-15 (Sun)
+// Earlier:   anything before 2026-03-09
 
 describe('groupWorkoutsByDate', () => {
-  // today = 2026-03-15 → "This Month" = March 2026, "Last Month" = February 2026
-  const today = '2026-03-15';
+  const today = '2026-03-18'; // Wednesday
 
   it('returns empty array for no workouts', () => {
     expect(groupWorkoutsByDate([], today)).toEqual([]);
   });
 
-  it('groups workouts in the current month into "This Month"', () => {
+  it('groups workouts in the current Mon–Sun week into "This Week"', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-03-01' }),
-      makeWorkout({ id: 'w2', date: '2026-03-15' }),
+      makeWorkout({ id: 'w1', date: '2026-03-16' }), // Mon
+      makeWorkout({ id: 'w2', date: '2026-03-18' }), // Wed (today)
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('This Month');
+    expect(groups[0].label).toBe('This Week');
     expect(groups[0].workouts).toHaveLength(2);
   });
 
-  it('groups workouts in the previous month into "Last Month"', () => {
+  it('groups workouts in the previous Mon–Sun week into "Last Week"', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-02-01' }),
-      makeWorkout({ id: 'w2', date: '2026-02-28' }),
+      makeWorkout({ id: 'w1', date: '2026-03-09' }), // Mon last week
+      makeWorkout({ id: 'w2', date: '2026-03-15' }), // Sun last week
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('Last Month');
+    expect(groups[0].label).toBe('Last Week');
     expect(groups[0].workouts).toHaveLength(2);
   });
 
-  it('groups older workouts by "Month Year"', () => {
+  it('groups workouts before last week into "Earlier"', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-01-15' }),
-      makeWorkout({ id: 'w2', date: '2025-12-20' }),
+      makeWorkout({ id: 'w1', date: '2026-03-08' }), // day before last Mon
+      makeWorkout({ id: 'w2', date: '2025-12-01' }),
     ];
-    const groups = groupWorkoutsByDate(workouts, today);
-    expect(groups).toHaveLength(2);
-    expect(groups[0].label).toBe('January 2026');
-    expect(groups[1].label).toBe('December 2025');
-  });
-
-  it('handles mixed groups in correct order', () => {
-    const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-03-10' }), // This Month
-      makeWorkout({ id: 'w2', date: '2026-02-20' }), // Last Month
-      makeWorkout({ id: 'w3', date: '2026-01-05' }), // January 2026
-      makeWorkout({ id: 'w4', date: '2025-11-10' }), // November 2025
-    ];
-    const groups = groupWorkoutsByDate(workouts, today);
-    expect(groups.map(g => g.label)).toEqual([
-      'This Month',
-      'Last Month',
-      'January 2026',
-      'November 2025',
-    ]);
-  });
-
-  it('omits empty groups', () => {
-    const workouts = [makeWorkout({ date: '2026-02-10' })];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe('Last Month');
+    expect(groups[0].label).toBe('Earlier');
+    expect(groups[0].workouts).toHaveLength(2);
   });
 
-  it('no duplicates — month boundary workout falls into exactly one group', () => {
-    // Mar 1 is "This Month", Feb 28 is "Last Month" — no overlap
-    // Input already sorted newest-first (as filteredWorkouts provides)
+  it('handles mixed groups in correct order: This Week → Last Week → Earlier', () => {
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-03-01' }),
-      makeWorkout({ id: 'w2', date: '2026-02-28' }),
+      makeWorkout({ id: 'w1', date: '2026-03-18' }), // This Week
+      makeWorkout({ id: 'w2', date: '2026-03-12' }), // Last Week
+      makeWorkout({ id: 'w3', date: '2026-03-01' }), // Earlier
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups.map(g => g.label)).toEqual(['This Week', 'Last Week', 'Earlier']);
+  });
+
+  it('omits empty sections', () => {
+    const workouts = [makeWorkout({ date: '2026-03-18' })];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('This Week');
+  });
+
+  it('no duplicates — week boundary workout falls into exactly one section', () => {
+    // Sunday of last week vs Monday of this week
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-16' }), // Mon this week
+      makeWorkout({ id: 'w2', date: '2026-03-15' }), // Sun last week
     ];
     const groups = groupWorkoutsByDate(workouts, today);
     expect(groups).toHaveLength(2);
-    expect(groups[0].label).toBe('This Month');
+    expect(groups[0].label).toBe('This Week');
     expect(groups[0].workouts).toHaveLength(1);
-    expect(groups[0].workouts[0].date).toBe('2026-03-01');
-    expect(groups[1].label).toBe('Last Month');
+    expect(groups[0].workouts[0].date).toBe('2026-03-16');
+    expect(groups[1].label).toBe('Last Week');
     expect(groups[1].workouts).toHaveLength(1);
-    expect(groups[1].workouts[0].date).toBe('2026-02-28');
+    expect(groups[1].workouts[0].date).toBe('2026-03-15');
   });
 
-  it('handles January today with December as Last Month', () => {
-    const janToday = '2026-01-15';
+  it('works correctly when today is Monday', () => {
+    // today = 2026-03-16 (Monday)
+    // This week: Mar 16–22; Last week: Mar 9–15
+    const monday = '2026-03-16';
     const workouts = [
-      makeWorkout({ id: 'w1', date: '2026-01-10' }),
-      makeWorkout({ id: 'w2', date: '2025-12-20' }),
+      makeWorkout({ id: 'w1', date: '2026-03-16' }), // This Week (today)
+      makeWorkout({ id: 'w2', date: '2026-03-15' }), // Last Week (Sun)
+      makeWorkout({ id: 'w3', date: '2026-03-09' }), // Last Week (Mon)
+      makeWorkout({ id: 'w4', date: '2026-03-08' }), // Earlier
     ];
-    const groups = groupWorkoutsByDate(workouts, janToday);
-    expect(groups[0].label).toBe('This Month');
-    expect(groups[1].label).toBe('Last Month');
+    const groups = groupWorkoutsByDate(workouts, monday);
+    expect(groups.map(g => g.label)).toEqual(['This Week', 'Last Week', 'Earlier']);
+    expect(groups[0].workouts).toHaveLength(1);
+    expect(groups[1].workouts).toHaveLength(2);
+    expect(groups[2].workouts).toHaveLength(1);
+  });
+
+  it('works correctly when today is Sunday', () => {
+    // today = 2026-03-22 (Sunday)
+    // This week: Mar 16–22; Last week: Mar 9–15
+    const sunday = '2026-03-22';
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-22' }), // This Week (today)
+      makeWorkout({ id: 'w2', date: '2026-03-16' }), // This Week (Mon)
+      makeWorkout({ id: 'w3', date: '2026-03-15' }), // Last Week (Sun)
+    ];
+    const groups = groupWorkoutsByDate(workouts, sunday);
+    expect(groups.map(g => g.label)).toEqual(['This Week', 'Last Week']);
+    expect(groups[0].workouts).toHaveLength(2);
+  });
+
+  it('preserves reverse-chronological order within each section', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-18' }),
+      makeWorkout({ id: 'w2', date: '2026-03-16' }),
+    ];
+    const groups = groupWorkoutsByDate(workouts, today);
+    expect(groups[0].workouts[0].date).toBe('2026-03-18');
+    expect(groups[0].workouts[1].date).toBe('2026-03-16');
   });
 });
 
@@ -201,8 +237,6 @@ describe('getWeekStreak', () => {
   });
 
   it('uses local dates (no UTC shift from toISOString)', () => {
-    // All generated dates should match the expected local-time dates,
-    // regardless of the runtime timezone offset
     const days = getWeekStreak([], '2026-03-15');
     const dates = days.map(d => d.date);
     expect(dates).toEqual([
@@ -281,19 +315,140 @@ describe('getWeekTotalMinutes', () => {
   });
 });
 
+// ── Last week stats ──────────────────────────────────────────────────
+// today = '2026-03-18' (Wed); last week = Mar 9–15
+
+describe('getLastWeekWorkoutCount', () => {
+  const today = '2026-03-18';
+
+  it('returns 0 for no workouts', () => {
+    expect(getLastWeekWorkoutCount([], today)).toBe(0);
+  });
+
+  it('counts workouts in the previous Mon–Sun week', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09' }), // Mon last week
+      makeWorkout({ id: 'w2', date: '2026-03-12' }), // Thu last week
+      makeWorkout({ id: 'w3', date: '2026-03-15' }), // Sun last week
+      makeWorkout({ id: 'w4', date: '2026-03-16' }), // This week (excluded)
+      makeWorkout({ id: 'w5', date: '2026-03-08' }), // Earlier (excluded)
+    ];
+    expect(getLastWeekWorkoutCount(workouts, today)).toBe(3);
+  });
+
+  it('returns 0 when no workouts fall in last week', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-17' }), // This week
+      makeWorkout({ id: 'w2', date: '2026-03-01' }), // Earlier
+    ];
+    expect(getLastWeekWorkoutCount(workouts, today)).toBe(0);
+  });
+
+  it('AC4: planned workouts filtered by caller are excluded', () => {
+    const completed = makeWorkout({ id: 'w1', date: '2026-03-11', status: '' });
+    expect(getLastWeekWorkoutCount([completed], today)).toBe(1);
+  });
+});
+
+describe('getLastWeekTotalMinutes', () => {
+  const today = '2026-03-18'; // last week = Mar 9–15
+
+  it('returns 0 for no workouts', () => {
+    expect(getLastWeekTotalMinutes([], today)).toBe(0);
+  });
+
+  it('sums durations for last week only', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-12', duration_min: '45' }),
+      makeWorkout({ id: 'w3', date: '2026-03-16', duration_min: '30' }), // This week (excluded)
+      makeWorkout({ id: 'w4', date: '2026-03-01', duration_min: '90' }), // Earlier (excluded)
+    ];
+    expect(getLastWeekTotalMinutes(workouts, today)).toBe(105);
+  });
+
+  it('skips workouts with no duration (contributes 0 min but still counted)', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-09', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-11', duration_min: '' }),
+    ];
+    expect(getLastWeekTotalMinutes(workouts, today)).toBe(60);
+  });
+});
+
+// ── This month stats ─────────────────────────────────────────────────
+// today = '2026-03-18'; this month = March 2026
+
+describe('getMonthWorkoutCount', () => {
+  const today = '2026-03-18';
+
+  it('returns 0 for no workouts', () => {
+    expect(getMonthWorkoutCount([], today)).toBe(0);
+  });
+
+  it('counts workouts in the current calendar month', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-01' }),
+      makeWorkout({ id: 'w2', date: '2026-03-15' }),
+      makeWorkout({ id: 'w3', date: '2026-03-18' }),
+      makeWorkout({ id: 'w4', date: '2026-02-28' }), // Last month (excluded)
+      makeWorkout({ id: 'w5', date: '2026-04-01' }), // Next month (excluded)
+    ];
+    expect(getMonthWorkoutCount(workouts, today)).toBe(3);
+  });
+
+  it('returns 0 when no workouts this month', () => {
+    const workouts = [makeWorkout({ date: '2026-02-15' })];
+    expect(getMonthWorkoutCount(workouts, today)).toBe(0);
+  });
+
+  it('handles January correctly (year boundary)', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-01-10' }),
+      makeWorkout({ id: 'w2', date: '2025-12-31' }), // Last year (excluded)
+    ];
+    expect(getMonthWorkoutCount(workouts, '2026-01-15')).toBe(1);
+  });
+
+  it('AC5: excludes planned workouts when caller passes completedWorkouts', () => {
+    const completed = makeWorkout({ id: 'w1', date: '2026-03-15', status: '' });
+    expect(getMonthWorkoutCount([completed], today)).toBe(1);
+  });
+});
+
+describe('getMonthTotalMinutes', () => {
+  const today = '2026-03-18';
+
+  it('returns 0 for no workouts', () => {
+    expect(getMonthTotalMinutes([], today)).toBe(0);
+  });
+
+  it('sums durations for this month only', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-01', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-15', duration_min: '45' }),
+      makeWorkout({ id: 'w3', date: '2026-02-28', duration_min: '90' }), // Last month (excluded)
+    ];
+    expect(getMonthTotalMinutes(workouts, today)).toBe(105);
+  });
+
+  it('AC4: workouts with no duration contribute 0 min but count in workout count', () => {
+    const workouts = [
+      makeWorkout({ id: 'w1', date: '2026-03-10', duration_min: '60' }),
+      makeWorkout({ id: 'w2', date: '2026-03-12', duration_min: '' }),
+    ];
+    expect(getMonthTotalMinutes(workouts, today)).toBe(60);
+    expect(getMonthWorkoutCount(workouts, today)).toBe(2);
+  });
+});
+
 // ── Planned workout exclusion (caller responsibility) ────────────────
-// The helpers receive pre-filtered workout lists. These tests confirm
-// that passing only completedWorkouts (status !== 'planned') correctly
-// excludes planned workouts from streak / stats.
 
 describe('week stats exclude planned workouts (via caller filtering)', () => {
   const today = '2026-03-15'; // week = Mar 9–15
 
   it('getWeekStreak: planned workouts filtered out by caller are not counted', () => {
-    const planned = makeWorkout({ id: 'w_planned', date: '2026-03-11', status: 'planned' });
     const completed = makeWorkout({ id: 'w_done', date: '2026-03-09', status: '' });
-
-    // Caller filters out planned before passing
     const completedOnly = [completed];
     const days = getWeekStreak(completedOnly, today);
 
@@ -302,14 +457,12 @@ describe('week stats exclude planned workouts (via caller filtering)', () => {
   });
 
   it('getWeekWorkoutCount: planned workouts filtered out by caller are not counted', () => {
-    const planned = makeWorkout({ id: 'w_planned', date: '2026-03-11', status: 'planned' });
     const completed = makeWorkout({ id: 'w_done', date: '2026-03-09', status: '' });
     const completedOnly = [completed];
     expect(getWeekWorkoutCount(completedOnly, today)).toBe(1);
   });
 
   it('getWeekTotalMinutes: planned workouts filtered out by caller are not summed', () => {
-    const planned = makeWorkout({ id: 'w_planned', date: '2026-03-11', duration_min: '45', status: 'planned' });
     const completed = makeWorkout({ id: 'w_done', date: '2026-03-09', duration_min: '60', status: '' });
     const completedOnly = [completed];
     expect(getWeekTotalMinutes(completedOnly, today)).toBe(60);

--- a/frontend/src/components/activities/activities-helpers.ts
+++ b/frontend/src/components/activities/activities-helpers.ts
@@ -3,22 +3,18 @@ import type { WorkoutWithRow, SetWithRow, ExerciseWithRow } from '../../api/type
 // ── Equipment / non-muscle tags to exclude from card pills ───────────
 export const EQUIPMENT_TAGS = new Set(['BB', 'DB', 'FT', 'Warmup']);
 
-// ── Date grouping (month-based) ──────────────────────────────────────
+// ── Date grouping (week-based) ───────────────────────────────────────
 
 export interface WorkoutGroup {
   label: string;
   workouts: WorkoutWithRow[];
 }
 
-const MONTH_NAMES = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-
 /**
- * Groups workouts into calendar-month buckets: "This Month", "Last Month",
- * then "Month Year" for older entries. Each workout appears in exactly one group.
- * Preserves the order of workouts within each group. Empty groups are omitted.
+ * Groups workouts into weekly sections: "This Week" (current Mon–Sun),
+ * "Last Week" (previous Mon–Sun), and "Earlier" (everything before last week).
+ * Each workout appears in exactly one section. Empty sections are omitted.
+ * Preserves the order of workouts within each section.
  */
 export function groupWorkoutsByDate(
   workouts: WorkoutWithRow[],
@@ -27,29 +23,28 @@ export function groupWorkoutsByDate(
   if (workouts.length === 0) return [];
 
   const today = new Date(todayStr + 'T00:00:00');
-  const thisYear = today.getFullYear();
-  const thisMonth = today.getMonth();
+  const day = today.getDay(); // 0=Sun…6=Sat
+  const diffToMonday = day === 0 ? 6 : day - 1;
 
-  const lastMonthDate = new Date(today);
-  lastMonthDate.setDate(1);
-  lastMonthDate.setMonth(lastMonthDate.getMonth() - 1);
-  const lastYear = lastMonthDate.getFullYear();
-  const lastMonth = lastMonthDate.getMonth();
+  const thisMonday = new Date(today);
+  thisMonday.setDate(today.getDate() - diffToMonday);
+
+  const lastMonday = new Date(thisMonday);
+  lastMonday.setDate(thisMonday.getDate() - 7);
+
+  const thisMondayStr = toLocalDateStr(thisMonday);
+  const lastMondayStr = toLocalDateStr(lastMonday);
 
   const groups = new Map<string, WorkoutWithRow[]>();
 
   for (const w of workouts) {
-    const d = new Date(w.date + 'T00:00:00');
-    const wYear = d.getFullYear();
-    const wMonth = d.getMonth();
-
     let label: string;
-    if (wYear === thisYear && wMonth === thisMonth) {
-      label = 'This Month';
-    } else if (wYear === lastYear && wMonth === lastMonth) {
-      label = 'Last Month';
+    if (w.date >= thisMondayStr) {
+      label = 'This Week';
+    } else if (w.date >= lastMondayStr) {
+      label = 'Last Week';
     } else {
-      label = `${MONTH_NAMES[wMonth]} ${wYear}`;
+      label = 'Earlier';
     }
 
     let arr = groups.get(label);
@@ -60,7 +55,11 @@ export function groupWorkoutsByDate(
     arr.push(w);
   }
 
-  return Array.from(groups.entries()).map(([label, wks]) => ({ label, workouts: wks }));
+  // Enforce canonical order regardless of insertion order
+  const ORDER = ['This Week', 'Last Week', 'Earlier'];
+  return ORDER
+    .filter(label => groups.has(label))
+    .map(label => ({ label, workouts: groups.get(label)! }));
 }
 
 // ── Weekly streak ────────────────────────────────────────────────────
@@ -139,6 +138,95 @@ export function getWeekTotalMinutes(
   let total = 0;
   for (const w of allWorkouts) {
     if (!weekDates.has(w.date)) continue;
+    const mins = parseInt(w.duration_min, 10);
+    if (!isNaN(mins)) total += mins;
+  }
+  return total;
+}
+
+// ── Last-week helpers ────────────────────────────────────────────────
+
+/** Returns the set of ISO date strings for the Mon–Sun week before `todayStr`. */
+function getLastWeekDateSet(todayStr: string): Set<string> {
+  const today = new Date(todayStr + 'T00:00:00');
+  const day = today.getDay();
+  const diffToMonday = day === 0 ? 6 : day - 1;
+
+  const thisMonday = new Date(today);
+  thisMonday.setDate(today.getDate() - diffToMonday);
+
+  const dates = new Set<string>();
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(thisMonday);
+    d.setDate(thisMonday.getDate() - 7 + i);
+    dates.add(toLocalDateStr(d));
+  }
+  return dates;
+}
+
+/**
+ * Returns the count of workouts in the Mon–Sun week prior to the week
+ * containing `todayStr`.
+ */
+export function getLastWeekWorkoutCount(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): number {
+  const lastWeekDates = getLastWeekDateSet(todayStr);
+  return allWorkouts.filter(w => lastWeekDates.has(w.date)).length;
+}
+
+/**
+ * Returns the total duration in minutes for workouts in the Mon–Sun week
+ * prior to the week containing `todayStr`.
+ */
+export function getLastWeekTotalMinutes(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): number {
+  const lastWeekDates = getLastWeekDateSet(todayStr);
+  let total = 0;
+  for (const w of allWorkouts) {
+    if (!lastWeekDates.has(w.date)) continue;
+    const mins = parseInt(w.duration_min, 10);
+    if (!isNaN(mins)) total += mins;
+  }
+  return total;
+}
+
+// ── This-month helpers ───────────────────────────────────────────────
+
+/**
+ * Returns the count of workouts in the current calendar month (1st to today).
+ */
+export function getMonthWorkoutCount(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): number {
+  const today = new Date(todayStr + 'T00:00:00');
+  const thisYear = today.getFullYear();
+  const thisMonth = today.getMonth();
+  return allWorkouts.filter(w => {
+    const d = new Date(w.date + 'T00:00:00');
+    return d.getFullYear() === thisYear && d.getMonth() === thisMonth;
+  }).length;
+}
+
+/**
+ * Returns the total duration in minutes for workouts in the current calendar
+ * month. Workouts with no duration contribute 0 minutes.
+ */
+export function getMonthTotalMinutes(
+  allWorkouts: WorkoutWithRow[],
+  todayStr: string,
+): number {
+  const today = new Date(todayStr + 'T00:00:00');
+  const thisYear = today.getFullYear();
+  const thisMonth = today.getMonth();
+  let total = 0;
+  for (const w of allWorkouts) {
+    const d = new Date(w.date + 'T00:00:00');
+    if (d.getFullYear() !== thisYear || d.getMonth() !== thisMonth) continue;
     const mins = parseInt(w.duration_min, 10);
     if (!isNaN(mins)) total += mins;
   }

--- a/frontend/src/components/activities/activities-screen.tsx
+++ b/frontend/src/components/activities/activities-screen.tsx
@@ -2,7 +2,18 @@ import { useState } from 'preact/hooks';
 import { navigate } from '../../router/router';
 import { filteredWorkouts, plannedWorkouts, completedWorkouts, sets, exercises } from '../../state/store';
 import { ActivitiesFilters } from './activities-filters';
-import { groupWorkoutsByDate, getWorkoutTags, getWeekStreak, getWeekWorkoutCount, getWeekTotalMinutes, toLocalDateStr } from './activities-helpers';
+import {
+  groupWorkoutsByDate,
+  getWorkoutTags,
+  getWeekStreak,
+  getWeekWorkoutCount,
+  getWeekTotalMinutes,
+  getLastWeekWorkoutCount,
+  getLastWeekTotalMinutes,
+  getMonthWorkoutCount,
+  getMonthTotalMinutes,
+  toLocalDateStr,
+} from './activities-helpers';
 import { LabelBadge } from '../shared/label-badge';
 
 /** Type-color map for inset box-shadow accent (light theme). */
@@ -13,18 +24,31 @@ const TYPE_COLORS: Record<string, { light: string; dark: string }> = {
   hike:    { light: '#5d4037', dark: '#d7ccc8' },
 };
 
+function pluralWorkout(n: number): string {
+  return `${n} ${n === 1 ? 'workout' : 'workouts'}`;
+}
+
 export function ActivitiesScreen() {
   const [showFilters, setShowFilters] = useState(false);
 
   const todayStr = toLocalDateStr(new Date());
   const groups = groupWorkoutsByDate(filteredWorkouts.value, todayStr);
   const planned = plannedWorkouts.value;
-  // Week stats use only completed workouts (planned workouts haven't happened yet)
-  const weekDays = getWeekStreak(completedWorkouts.value, todayStr);
-  const weekCount = getWeekWorkoutCount(completedWorkouts.value, todayStr);
-  const weekMinutes = getWeekTotalMinutes(completedWorkouts.value, todayStr);
-  const countText = `${weekCount} ${weekCount === 1 ? 'workout' : 'workouts'} this week`;
-  const ariaLabel = weekMinutes > 0 ? `${countText}, ${weekMinutes} min` : countText;
+  // All stats use only completed workouts (planned workouts haven't happened yet)
+  const completed = completedWorkouts.value;
+  const weekDays = getWeekStreak(completed, todayStr);
+  const weekCount = getWeekWorkoutCount(completed, todayStr);
+  const weekMinutes = getWeekTotalMinutes(completed, todayStr);
+  const lastWeekCount = getLastWeekWorkoutCount(completed, todayStr);
+  const lastWeekMinutes = getLastWeekTotalMinutes(completed, todayStr);
+  const monthCount = getMonthWorkoutCount(completed, todayStr);
+  const monthMinutes = getMonthTotalMinutes(completed, todayStr);
+
+  const statsAriaLabel = [
+    `${pluralWorkout(weekCount)} this week, ${weekMinutes} minutes.`,
+    `${pluralWorkout(lastWeekCount)} last week, ${lastWeekMinutes} minutes.`,
+    `${pluralWorkout(monthCount)} this month, ${monthMinutes} minutes.`,
+  ].join(' ');
 
   return (
     <div class="screen activities-screen">
@@ -46,10 +70,7 @@ export function ActivitiesScreen() {
         </div>
       </header>
 
-      <div
-        class="week-streak-bar"
-        aria-label={ariaLabel}
-      >
+      <div class="week-streak-bar">
         <div class="week-streak-dots" aria-hidden="true">
           {weekDays.map((d) => (
             <div
@@ -63,9 +84,23 @@ export function ActivitiesScreen() {
             <span key={d.date} class={`streak-label${d.isToday ? ' today' : ''}`}>{d.label}</span>
           ))}
         </div>
-        <p class="week-streak-count">
-          {countText}{weekMinutes > 0 ? ` · ${weekMinutes} min` : ''}
-        </p>
+        <div
+          class="stats-bar"
+          aria-label={statsAriaLabel}
+        >
+          <div class="stats-bar-cell" aria-hidden="true">
+            <span class="stats-bar-label">This week</span>
+            <span class="stats-bar-value">{pluralWorkout(weekCount)} · {weekMinutes} min</span>
+          </div>
+          <div class="stats-bar-cell stats-bar-cell--center" aria-hidden="true">
+            <span class="stats-bar-label">Last week</span>
+            <span class="stats-bar-value">{pluralWorkout(lastWeekCount)} · {lastWeekMinutes} min</span>
+          </div>
+          <div class="stats-bar-cell stats-bar-cell--right" aria-hidden="true">
+            <span class="stats-bar-label">This month</span>
+            <span class="stats-bar-value">{pluralWorkout(monthCount)} · {monthMinutes} min</span>
+          </div>
+        </div>
       </div>
 
       {showFilters && <ActivitiesFilters />}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1703,10 +1703,37 @@ input, select, textarea {
   font-weight: 600;
 }
 
-.week-streak-count {
+.stats-bar {
+  display: flex;
+  gap: 0;
+  margin-top: var(--space-xs);
+}
+
+.stats-bar-cell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stats-bar-cell--center {
+  text-align: center;
+}
+
+.stats-bar-cell--right {
+  text-align: right;
+}
+
+.stats-bar-label {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
-  margin: 0;
+  line-height: 1.2;
+}
+
+.stats-bar-value {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.2;
 }
 
 /* ===== Workout Card Enhancements ===== */


### PR DESCRIPTION
Closes #69

## Changes

- **`activities-helpers.ts`**: Replace `groupWorkoutsByDate()` month logic with week-based grouping (This Week / Last Week / Earlier). Add `getLastWeekWorkoutCount()`, `getLastWeekTotalMinutes()`, `getMonthWorkoutCount()`, `getMonthTotalMinutes()`.
- **`activities-screen.tsx`**: Replace single `week-streak-count` paragraph with 3-column stacked stats bar (This week · Last week · This month), each showing `N workout(s) · X min`. Container has `aria-label` with full readable summary; cells are `aria-hidden`.
- **`global.css`**: Add `.stats-bar` flexbox layout and `.stats-bar-cell/label/value` styles using `--color-text-muted` for labels and `--color-text-secondary` for values.
- **`activities-helpers.test.ts`**: Update `groupWorkoutsByDate` tests for week-based logic; add full test coverage for all four new helper functions.

## Test coverage

- 309 tests pass (22 test files)
- `tsc --noEmit` clean
- Production build clean