### PR TITLE
feat: hexagonal orange dumbbell icon (#77)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Thrive — Workout Tracker</title>
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#4f6ef7" />
+  <meta name="theme-color" content="#FF6B35" />
   <link rel="icon" type="image/svg+xml" sizes="any" href="thrive-favicon.svg" />
   <link rel="apple-touch-icon" href="thrive-icon-192.svg" />
   <!-- Apply data-theme before first paint to prevent flash of wrong theme -->

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/thrive/",
   "display": "standalone",
   "background_color": "#f8f9fa",
-  "theme_color": "#4f6ef7",
+  "theme_color": "#FF6B35",
   "icons": [
     {
       "src": "thrive-icon-192.svg",

--- a/frontend/public/thrive-favicon.svg
+++ b/frontend/public/thrive-favicon.svg
@@ -1,7 +1,13 @@
-<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" rx="12" fill="#4f6ef7"/>
-  <rect x="10" y="42" width="44" height="3" fill="white"/>
-  <rect x="24" y="32" width="16" height="3" fill="white"/>
-  <rect x="19" y="29" width="4" height="9" fill="white"/>
-  <rect x="41" y="29" width="4" height="9" fill="white"/>
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="#FF6B35" points="128,24 210,72 210,170 128,218 46,170 46,72"/>
+  <g transform="translate(128 121) scale(1.8)">
+    <g fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="butt">
+      <rect x="-36" y="-16" width="9" height="32" rx="4"/>
+      <rect x="-25" y="-22" width="11" height="44" rx="5"/>
+      <rect x="14" y="-22" width="11" height="44" rx="5"/>
+      <rect x="27" y="-16" width="9" height="32" rx="4"/>
+    </g>
+    <rect x="-16" y="-3" width="32" height="6" fill="#FFFFFF"/>
+    <rect x="-14" y="-3" width="28" height="6" fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5"/>
+  </g>
 </svg>

--- a/frontend/public/thrive-icon-192-maskable.svg
+++ b/frontend/public/thrive-icon-192-maskable.svg
@@ -1,9 +1,14 @@
-<svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
-  <rect width="192" height="192" fill="#4f6ef7"/>
-  <g transform="translate(48, 48) scale(1.5)">
-    <rect x="10" y="42" width="44" height="3" fill="white"/>
-    <rect x="24" y="32" width="16" height="3" fill="white"/>
-    <rect x="19" y="29" width="4" height="9" fill="white"/>
-    <rect x="41" y="29" width="4" height="9" fill="white"/>
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" fill="#FF6B35"/>
+  <polygon fill="#FF6B35" points="128,36 200,78 200,164 128,206 56,164 56,78"/>
+  <g transform="translate(128 121) scale(1.5)">
+    <g fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="butt">
+      <rect x="-36" y="-16" width="9" height="32" rx="4"/>
+      <rect x="-25" y="-22" width="11" height="44" rx="5"/>
+      <rect x="14" y="-22" width="11" height="44" rx="5"/>
+      <rect x="27" y="-16" width="9" height="32" rx="4"/>
+    </g>
+    <rect x="-16" y="-3" width="32" height="6" fill="#FFFFFF"/>
+    <rect x="-14" y="-3" width="28" height="6" fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5"/>
   </g>
 </svg>

--- a/frontend/public/thrive-icon-192.svg
+++ b/frontend/public/thrive-icon-192.svg
@@ -1,9 +1,13 @@
-<svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
-  <rect width="192" height="192" rx="32" fill="#4f6ef7"/>
-  <g transform="translate(32, 32) scale(2)">
-    <rect x="10" y="42" width="44" height="3" fill="white"/>
-    <rect x="24" y="32" width="16" height="3" fill="white"/>
-    <rect x="19" y="29" width="4" height="9" fill="white"/>
-    <rect x="41" y="29" width="4" height="9" fill="white"/>
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="#FF6B35" points="128,24 210,72 210,170 128,218 46,170 46,72"/>
+  <g transform="translate(128 121) scale(1.8)">
+    <g fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="butt">
+      <rect x="-36" y="-16" width="9" height="32" rx="4"/>
+      <rect x="-25" y="-22" width="11" height="44" rx="5"/>
+      <rect x="14" y="-22" width="11" height="44" rx="5"/>
+      <rect x="27" y="-16" width="9" height="32" rx="4"/>
+    </g>
+    <rect x="-16" y="-3" width="32" height="6" fill="#FFFFFF"/>
+    <rect x="-14" y="-3" width="28" height="6" fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5"/>
   </g>
 </svg>

--- a/frontend/public/thrive-icon-512-maskable.svg
+++ b/frontend/public/thrive-icon-512-maskable.svg
@@ -1,9 +1,14 @@
-<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <rect width="512" height="512" fill="#4f6ef7"/>
-  <g transform="translate(128, 128) scale(4)">
-    <rect x="10" y="42" width="44" height="3" fill="white"/>
-    <rect x="24" y="32" width="16" height="3" fill="white"/>
-    <rect x="19" y="29" width="4" height="9" fill="white"/>
-    <rect x="41" y="29" width="4" height="9" fill="white"/>
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" fill="#FF6B35"/>
+  <polygon fill="#FF6B35" points="128,36 200,78 200,164 128,206 56,164 56,78"/>
+  <g transform="translate(128 121) scale(1.5)">
+    <g fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="butt">
+      <rect x="-36" y="-16" width="9" height="32" rx="4"/>
+      <rect x="-25" y="-22" width="11" height="44" rx="5"/>
+      <rect x="14" y="-22" width="11" height="44" rx="5"/>
+      <rect x="27" y="-16" width="9" height="32" rx="4"/>
+    </g>
+    <rect x="-16" y="-3" width="32" height="6" fill="#FFFFFF"/>
+    <rect x="-14" y="-3" width="28" height="6" fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5"/>
   </g>
 </svg>

--- a/frontend/public/thrive-icon-512.svg
+++ b/frontend/public/thrive-icon-512.svg
@@ -1,9 +1,13 @@
-<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <rect width="512" height="512" rx="80" fill="#4f6ef7"/>
-  <g transform="translate(96, 96) scale(5)">
-    <rect x="10" y="42" width="44" height="3" fill="white"/>
-    <rect x="24" y="32" width="16" height="3" fill="white"/>
-    <rect x="19" y="29" width="4" height="9" fill="white"/>
-    <rect x="41" y="29" width="4" height="9" fill="white"/>
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <polygon fill="#FF6B35" points="128,24 210,72 210,170 128,218 46,170 46,72"/>
+  <g transform="translate(128 121) scale(1.8)">
+    <g fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="butt">
+      <rect x="-36" y="-16" width="9" height="32" rx="4"/>
+      <rect x="-25" y="-22" width="11" height="44" rx="5"/>
+      <rect x="14" y="-22" width="11" height="44" rx="5"/>
+      <rect x="27" y="-16" width="9" height="32" rx="4"/>
+    </g>
+    <rect x="-16" y="-3" width="32" height="6" fill="#FFFFFF"/>
+    <rect x="-14" y="-3" width="28" height="6" fill="#FFFFFF" stroke="#1E1E1E" stroke-width="2.5"/>
   </g>
 </svg>

--- a/frontend/src/auth/login-screen.tsx
+++ b/frontend/src/auth/login-screen.tsx
@@ -1,17 +1,12 @@
 import { useAuth } from './auth-context';
+import { ThriveLogo } from '../components/shared/thrive-logo';
 
 export function LoginScreen() {
   const { login } = useAuth();
   return (
     <div class="login-screen">
       <div class="login-card">
-        <img
-          src={`${import.meta.env.BASE_URL}thrive-favicon.svg`}
-          alt=""
-          class="login-icon"
-          width="64"
-          height="64"
-        />
+        <ThriveLogo size={64} class="login-icon" />
         <h1>Thrive</h1>
         <p>Personal Workout Tracker</p>
         <button class="login-btn" onClick={login}>

--- a/frontend/src/components/shared/thrive-logo.test.tsx
+++ b/frontend/src/components/shared/thrive-logo.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { ThriveLogo } from './thrive-logo';
+
+describe('ThriveLogo — AC2: inline SVG component', () => {
+  it('renders an inline <svg> element, not an <img>', () => {
+    const { container } = render(<ThriveLogo />);
+    const svg = container.querySelector('svg');
+    const img = container.querySelector('img');
+    expect(svg).toBeTruthy();
+    expect(img).toBeNull();
+  });
+
+  it('has aria-hidden="true" for decorative use', () => {
+    const { container } = render(<ThriveLogo />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('defaults to size 24', () => {
+    const { container } = render(<ThriveLogo />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('24');
+    expect(svg?.getAttribute('height')).toBe('24');
+  });
+
+  it('accepts a custom size prop', () => {
+    const { container } = render(<ThriveLogo size={64} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('64');
+    expect(svg?.getAttribute('height')).toBe('64');
+  });
+
+  it('uses var(--color-accent) for hexagon fill', () => {
+    const { container } = render(<ThriveLogo />);
+    const polygon = container.querySelector('polygon');
+    expect(polygon?.getAttribute('fill')).toBe('var(--color-accent)');
+  });
+
+  it('contains a hexagon polygon', () => {
+    const { container } = render(<ThriveLogo />);
+    const polygon = container.querySelector('polygon');
+    expect(polygon).toBeTruthy();
+    expect(polygon?.getAttribute('points')).toContain('128');
+  });
+
+  it('passes class prop through to the svg element', () => {
+    const { container } = render(<ThriveLogo class="login-icon" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.classList.contains('login-icon')).toBe(true);
+  });
+});

--- a/frontend/src/components/shared/thrive-logo.tsx
+++ b/frontend/src/components/shared/thrive-logo.tsx
@@ -1,0 +1,31 @@
+interface ThriveLogoProps {
+  size?: number;
+  class?: string;
+}
+
+export function ThriveLogo({ size = 24, class: className }: ThriveLogoProps) {
+  return (
+    <svg
+      viewBox="0 0 256 256"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      aria-hidden="true"
+      class={className}
+    >
+      <polygon
+        fill="var(--color-accent)"
+        points="128,24 210,72 210,170 128,218 46,170 46,72"
+      />
+      <g transform="translate(128 121) scale(1.8)">
+        <g fill="#FFFFFF">
+          <rect x="-36" y="-16" width="9" height="32" rx="4" />
+          <rect x="-25" y="-22" width="11" height="44" rx="5" />
+          <rect x="14" y="-22" width="11" height="44" rx="5" />
+          <rect x="27" y="-16" width="9" height="32" rx="4" />
+        </g>
+        <rect x="-14" y="-3" width="28" height="6" fill="#FFFFFF" />
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -37,6 +37,9 @@
 
   /* Bottom nav height */
   --nav-height: 64px;
+
+  /* Brand accent (does not invert in dark mode) */
+  --color-accent: #FF6B35;
 }
 
 /* ===== Light Theme ===== */


### PR DESCRIPTION
Closes #77

## Changes
- Created `ThriveLogo` inline SVG component (`thrive-logo.tsx`) with `size` prop, `aria-hidden="true"`, and `class` passthrough
- Updated `login-screen.tsx` to use `<ThriveLogo size={64} class="login-icon" />` instead of `<img>`
- Defined `--color-accent: #FF6B35` in `global.css` `:root` block
- Replaced all 5 `thrive-*.svg` icon files with orange hexagon + white dumbbell design
- Maskable variants use full-canvas orange background with ~10% safe-zone padding
- Updated `theme_color` in `manifest.json` and `theme-color` meta in `index.html` to `#FF6B35`

## Test plan
- [x] 7 new ThriveLogo component tests pass (inline SVG, aria-hidden, size prop, class passthrough, hexagon fill)
- [x] All 354 tests pass
- [x] TypeScript clean
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)