### PR TITLE
feat: align design tokens with shared system

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "groundwork-frontend",
+  "name": "thrive-frontend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "groundwork-frontend",
+      "name": "thrive-frontend",
       "version": "1.0.0",
       "dependencies": {
         "@preact/signals": "^2.0.0",
@@ -15,6 +15,7 @@
         "@preact/preset-vite": "^2.9.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
+        "@types/node": "^25.5.0",
         "jsdom": "^28.1.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
@@ -1674,6 +1675,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -4000,6 +4011,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@preact/preset-vite": "^2.9.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
+    "@types/node": "^25.5.0",
     "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",

--- a/frontend/src/design-tokens.test.ts
+++ b/frontend/src/design-tokens.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const css = readFileSync(resolve(__dirname, 'global.css'), 'utf-8');
+
+// Helper: extract value of a CSS custom property from a named block
+function tokenValue(block: string, token: string): string | null {
+  const re = new RegExp(`${token.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')}\\s*:\\s*([^;]+);`);
+  const m = block.match(re);
+  return m ? m[1].trim() : null;
+}
+
+const rootBlock = css.match(/:root\s*\{([^}]+)\}/)?.[1] ?? '';
+const lightBlock = css.match(/\[data-theme="light"\]\s*\{([^}]+)\}/)?.[1] ?? '';
+const darkBlock = css.match(/\[data-theme="dark"\]\s*\{([^}]+)\}/)?.[1] ?? '';
+const loginCardH1Block = css.match(/\.login-card h1\s*\{([^}]+)\}/)?.[1] ?? '';
+const loginCardBlock = css.match(/\.login-card\s*\{([^}]+)\}/)?.[1] ?? '';
+
+describe('AC1: border radius tokens', () => {
+  it('--radius-sm is 4px', () => {
+    expect(tokenValue(rootBlock, '--radius-sm')).toBe('4px');
+  });
+  it('--radius-md is 8px', () => {
+    expect(tokenValue(rootBlock, '--radius-md')).toBe('8px');
+  });
+  it('--radius alias is 8px', () => {
+    expect(tokenValue(rootBlock, '--radius')).toBe('8px');
+  });
+  it('--radius-lg remains 16px', () => {
+    expect(tokenValue(rootBlock, '--radius-lg')).toBe('16px');
+  });
+  it('--radius-full remains 9999px', () => {
+    expect(tokenValue(rootBlock, '--radius-full')).toBe('9999px');
+  });
+});
+
+describe('AC2: background and border-light tokens (light mode)', () => {
+  it('--color-bg is #f0f2f5', () => {
+    expect(tokenValue(lightBlock, '--color-bg')).toBe('#f0f2f5');
+  });
+  it('--color-border-light is #e4e8ec', () => {
+    expect(tokenValue(lightBlock, '--color-border-light')).toBe('#e4e8ec');
+  });
+});
+
+describe('AC3: overlay tokens defined in both themes', () => {
+  const overlayTokens = [
+    '--overlay-xs',
+    '--overlay-sm',
+    '--overlay-md',
+    '--overlay-lg',
+    '--overlay-xl',
+    '--overlay-2xl',
+    '--overlay-3xl',
+    '--overlay-4xl',
+  ];
+  const lightAlphas = ['0.04', '0.08', '0.12', '0.16', '0.24', '0.32', '0.40', '0.60'];
+
+  overlayTokens.forEach((token, i) => {
+    it(`light: ${token} = rgba(0,0,0,${lightAlphas[i]})`, () => {
+      const val = tokenValue(lightBlock, token);
+      expect(val).not.toBeNull();
+      expect(val).toMatch(new RegExp(`rgba\\(0,\\s*0,\\s*0,\\s*${lightAlphas[i]}\\)`));
+    });
+  });
+
+  it('dark: --overlay-xs through --overlay-3xl use rgba(255,255,255,...)', () => {
+    ['--overlay-xs', '--overlay-sm', '--overlay-md', '--overlay-lg', '--overlay-xl', '--overlay-2xl', '--overlay-3xl'].forEach((token) => {
+      const val = tokenValue(darkBlock, token);
+      expect(val).not.toBeNull();
+      expect(val).toMatch(/rgba\(255,\s*255,\s*255,/);
+    });
+  });
+
+  it('dark: --overlay-4xl uses rgba(0,0,0,0.60)', () => {
+    const val = tokenValue(darkBlock, '--overlay-4xl');
+    expect(val).not.toBeNull();
+    expect(val).toMatch(/rgba\(0,\s*0,\s*0,\s*0\.60\)/);
+  });
+
+  it('--color-overlay is retained in light theme', () => {
+    expect(tokenValue(lightBlock, '--color-overlay')).not.toBeNull();
+  });
+});
+
+describe('AC4: composite shadow tokens', () => {
+  it('--shadow is defined in :root', () => {
+    expect(tokenValue(rootBlock, '--shadow')).not.toBeNull();
+  });
+  it('--shadow-lg is defined in :root', () => {
+    expect(tokenValue(rootBlock, '--shadow-lg')).not.toBeNull();
+  });
+  it('--shadow-strong is defined in :root', () => {
+    expect(tokenValue(rootBlock, '--shadow-strong')).not.toBeNull();
+  });
+  it('--color-shadow is retained in light theme', () => {
+    expect(tokenValue(lightBlock, '--color-shadow')).not.toBeNull();
+  });
+  it('--color-shadow-strong is retained in light theme', () => {
+    expect(tokenValue(lightBlock, '--color-shadow-strong')).not.toBeNull();
+  });
+  it('--shadow has correct value', () => {
+    const val = tokenValue(rootBlock, '--shadow');
+    expect(val).toContain('0 1px 3px rgba(0,0,0,0.15)');
+    expect(val).toContain('0 1px 2px rgba(0,0,0,0.05)');
+  });
+  it('--shadow-lg has correct value', () => {
+    expect(tokenValue(rootBlock, '--shadow-lg')).toBe('0 4px 12px rgba(0,0,0,0.15)');
+  });
+  it('--shadow-strong has correct value', () => {
+    expect(tokenValue(rootBlock, '--shadow-strong')).toBe('0 4px 24px rgba(0,0,0,0.15)');
+  });
+});
+
+describe('AC5: login title uses var(--color-text)', () => {
+  it('.login-card h1 color is var(--color-text)', () => {
+    expect(tokenValue(loginCardH1Block, 'color')).toBe('var(--color-text)');
+  });
+});
+
+describe('AC6: login card max-width is 400px', () => {
+  it('.login-card max-width is 400px', () => {
+    expect(tokenValue(loginCardBlock, 'max-width')).toBe('400px');
+  });
+});

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -16,8 +16,9 @@
   --space-2xl: 48px;
 
   /* Border radius */
-  --radius-sm: 6px;
-  --radius-md: 10px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius: 8px;
   --radius-lg: 16px;
   --radius-full: 9999px;
 
@@ -40,15 +41,20 @@
 
   /* Brand accent (does not invert in dark mode) */
   --color-accent: #FF6B35;
+
+  /* Composite shadows (light-mode optimized — add dark-mode overrides before use in dark contexts) */
+  --shadow: 0 1px 3px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.15);
+  --shadow-strong: 0 4px 24px rgba(0,0,0,0.15);
 }
 
 /* ===== Light Theme ===== */
 [data-theme="light"] {
-  --color-bg: #f8f9fa;
+  --color-bg: #f0f2f5;
   --color-surface: #ffffff;
   --color-surface-raised: #ffffff;
   --color-border: #e2e6ea;
-  --color-border-light: #f0f2f4;
+  --color-border-light: #e4e8ec;
   --color-text: #1a1d21;
   --color-text-secondary: #5f6b7a;
   --color-text-muted: #8e99a4;
@@ -64,6 +70,14 @@
   --color-overlay: rgba(0, 0, 0, 0.4);
   --color-shadow: rgba(0, 0, 0, 0.08);
   --color-shadow-strong: rgba(0, 0, 0, 0.15);
+  --overlay-xs: rgba(0, 0, 0, 0.04);
+  --overlay-sm: rgba(0, 0, 0, 0.08);
+  --overlay-md: rgba(0, 0, 0, 0.12);
+  --overlay-lg: rgba(0, 0, 0, 0.16);
+  --overlay-xl: rgba(0, 0, 0, 0.24);
+  --overlay-2xl: rgba(0, 0, 0, 0.32);
+  --overlay-3xl: rgba(0, 0, 0, 0.40);
+  --overlay-4xl: rgba(0, 0, 0, 0.60);
 }
 
 /* ===== Dark Theme ===== */
@@ -88,6 +102,14 @@
   --color-overlay: rgba(0, 0, 0, 0.6);
   --color-shadow: rgba(0, 0, 0, 0.25);
   --color-shadow-strong: rgba(0, 0, 0, 0.4);
+  --overlay-xs: rgba(255, 255, 255, 0.04);
+  --overlay-sm: rgba(255, 255, 255, 0.08);
+  --overlay-md: rgba(255, 255, 255, 0.12);
+  --overlay-lg: rgba(255, 255, 255, 0.16);
+  --overlay-xl: rgba(255, 255, 255, 0.24);
+  --overlay-2xl: rgba(255, 255, 255, 0.32);
+  --overlay-3xl: rgba(255, 255, 255, 0.40);
+  --overlay-4xl: rgba(0, 0, 0, 0.60);
 }
 
 /* ===== Base Styles ===== */
@@ -165,7 +187,7 @@ input, select, textarea {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
   box-shadow: 0 4px 24px var(--color-shadow);
-  max-width: 360px;
+  max-width: 400px;
   width: 100%;
 }
 
@@ -178,7 +200,7 @@ input, select, textarea {
   font-size: var(--text-2xl);
   font-weight: 700;
   margin-bottom: var(--space-xs);
-  color: var(--color-primary);
+  color: var(--color-text);
 }
 
 .login-card p {


### PR DESCRIPTION
Closes #80

## Changes
- **Border radius**: `--radius-sm` 6→4px, `--radius-md` 10→8px, `--radius` alias added
- **Light mode tokens**: `--color-bg` `#f8f9fa`→`#f0f2f5`, `--color-border-light` `#f0f2f4`→`#e4e8ec` (prevents contrast collision where borders would disappear against the new background)
- **Overlay scale**: `--overlay-xs` through `--overlay-4xl` added in both themes (light: `rgba(0,0,0,α)`, dark: `rgba(255,255,255,α)` for xs–3xl; `rgba(0,0,0,0.60)` for 4xl)
- **Composite shadows**: `--shadow`, `--shadow-lg`, `--shadow-strong` added to `:root` with code comment flagging dark-mode overrides needed before use; existing `--color-shadow`/`--color-shadow-strong` retained
- **Login title**: `.login-card h1` color `var(--color-primary)` → `var(--color-text)`
- **Login card**: `max-width` 360px → 400px
- **`@types/node`** added to devDependencies (needed for `fs` in CSS token tests)
- 28 new tests covering all 6 ACs in `design-tokens.test.ts`