### PR TITLE
feat: move planned reps to right of reps input in set row

### DIFF
--- a/frontend/src/components/workout/exercise-row.tsx
+++ b/frontend/src/components/workout/exercise-row.tsx
@@ -277,9 +277,6 @@ export function ExerciseRow({
 
       <div class="quick-fill-row">
         <span class="quick-fill-spacer" aria-hidden="true" />
-        {exercise.sets.some(s => s.planned_reps) && (
-          <span class="quick-fill-planned-spacer" aria-hidden="true" />
-        )}
         <div class="set-inputs">
           <input
             id={`quick-fill-wt-${exercise.exercise_id}-${exercise.exercise_order}`}

--- a/frontend/src/components/workout/set-row.test.ts
+++ b/frontend/src/components/workout/set-row.test.ts
@@ -19,6 +19,62 @@ function makeSet(overrides: Partial<TrackerSet> = {}): TrackerSet {
 
 const noop = () => {};
 
+describe('SetRow — planned reps position (issue #91)', () => {
+  // AC1: planned_reps appears inside .set-inputs after the reps input
+  it('renders planned reps inside .set-inputs when provided', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ planned_reps: '6' }), onUpdate: noop, onRemove: noop })
+    );
+    const setInputs = container.querySelector('.set-inputs');
+    expect(setInputs).not.toBeNull();
+    const planned = setInputs!.querySelector('.set-planned-target');
+    expect(planned).not.toBeNull();
+  });
+
+  // AC1: old .tracker-set-planned span outside .set-inputs is gone
+  it('does not render .tracker-set-planned outside .set-inputs', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ planned_reps: '6' }), onUpdate: noop, onRemove: noop })
+    );
+    const trackerSet = container.querySelector('.tracker-set');
+    // .tracker-set-planned should not be a direct child of .tracker-set
+    const oldPlanned = trackerSet!.querySelector(':scope > .tracker-set-planned');
+    expect(oldPlanned).toBeNull();
+  });
+
+  // AC2: nothing rendered when planned_reps is empty
+  it('does not render planned reps element when planned_reps is empty', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ planned_reps: '' }), onUpdate: noop, onRemove: noop })
+    );
+    expect(container.querySelector('.set-planned-target')).toBeNull();
+  });
+
+  // AC3: DOM order inside .set-inputs is weight → separator → reps → planned-reps
+  it('renders planned reps after reps input inside .set-inputs', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ planned_reps: '4-6' }), onUpdate: noop, onRemove: noop })
+    );
+    const setInputs = container.querySelector('.set-inputs')!;
+    const children = Array.from(setInputs.children);
+    const repsInput = setInputs.querySelector('.set-reps-input')!;
+    const planned = setInputs.querySelector('.set-planned-target')!;
+    expect(children.indexOf(repsInput)).toBeLessThan(children.indexOf(planned));
+  });
+
+  // AC5: aria-label conveys target reps meaningfully; visual prefix is aria-hidden
+  it('has accessible aria-label and aria-hidden prefix on planned reps span', () => {
+    const { container } = render(
+      SetRow({ set: makeSet({ planned_reps: '6' }), onUpdate: noop, onRemove: noop })
+    );
+    const planned = container.querySelector('.set-planned-target') as HTMLElement;
+    expect(planned.getAttribute('aria-label')).toBe('target: 6 reps');
+    const prefix = planned.querySelector('[aria-hidden]') as HTMLElement;
+    expect(prefix).not.toBeNull();
+    expect(prefix.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
 describe('SetRow — saved checkmark layout (issue #26)', () => {
   // AC1 + AC2: The .set-saved span is always in the DOM (reserves space)
   it('always renders the .set-saved span regardless of saved state', () => {

--- a/frontend/src/components/workout/set-row.tsx
+++ b/frontend/src/components/workout/set-row.tsx
@@ -25,10 +25,6 @@ export function SetRow({ set, onUpdate, onRemove }: Props) {
     <div class="tracker-set">
       <span class="tracker-set-number">S{set.set_number}</span>
 
-      {set.planned_reps && (
-        <span class="tracker-set-planned">{set.planned_reps}</span>
-      )}
-
       <div class="set-inputs">
         <input
           class="form-input set-weight-input"
@@ -47,6 +43,11 @@ export function SetRow({ set, onUpdate, onRemove }: Props) {
           value={set.reps}
           onInput={(e) => onUpdate({ reps: (e.target as HTMLInputElement).value })}
         />
+        {set.planned_reps && (
+          <span class="set-planned-target" aria-label={`target: ${set.planned_reps} reps`}>
+            <span aria-hidden="true">/ </span>{set.planned_reps}
+          </span>
+        )}
       </div>
 
       <div class="effort-toggle">

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1647,10 +1647,6 @@ input, select, textarea {
   min-width: 24px;
 }
 
-.quick-fill-planned-spacer {
-  min-width: 32px;
-}
-
 .quick-fill-end-spacer {
   /* set-saved (16px) + gap (4px) + set-remove-btn (24px) */
   min-width: 44px;

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1691,11 +1691,9 @@ input, select, textarea {
   text-align: center;
 }
 
-.tracker-set-planned {
+.set-planned-target {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
-  min-width: 32px;
-  text-align: center;
 }
 
 .set-inputs {


### PR DESCRIPTION
Closes #91

## Changes
- Moved `planned_reps` display from between the set number and weight input to inside `.set-inputs`, immediately after the reps input
- Formatted as muted `/ 6` text with `aria-label="target: 6 reps"` and `aria-hidden` on the visual `/` prefix for screen reader accessibility
- Renamed CSS class `.tracker-set-planned` → `.set-planned-target`, removed the reserved `min-width`
- Added 5 new tests covering position, empty state, DOM order, and accessibility (AC1–AC5)

## Before / After
**Before:** `S1  6  [lbs] × [reps]  E M H  ✓ ×`  
**After:**  `S1  [lbs] × [reps] /6  E M H  ✓ ×`