### PR TITLE
fix: deduplicate warmup exercises in workout tracker (#93)

### DIFF
--- a/frontend/src/components/workout/build-exercise-list.test.ts
+++ b/frontend/src/components/workout/build-exercise-list.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { buildExerciseList, mergeWarmups } from './build-exercise-list';
+import type { TrackerExercise } from './exercise-row';
+import type { SetWithRow } from '../../api/types';
+
+function makeSetRow(overrides: Partial<SetWithRow> = {}): SetWithRow {
+  return {
+    workout_id: 'w1',
+    exercise_id: 'ex1',
+    exercise_name: 'Bench Press',
+    section: 'primary',
+    exercise_order: 1,
+    set_number: 1,
+    planned_reps: '8-10',
+    weight: '',
+    reps: '',
+    effort: '',
+    notes: '',
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+function makeExercise(overrides: Partial<TrackerExercise> = {}): TrackerExercise {
+  return {
+    exercise_id: 'ex1',
+    exercise_name: 'Bench Press',
+    section: 'primary',
+    exercise_order: 1,
+    sets: [],
+    quickFillWeight: '',
+    quickFillReps: '',
+    quickFillEffort: '',
+    ...overrides,
+  };
+}
+
+describe('buildExerciseList', () => {
+  it('groups set rows by exercise_id + exercise_order', () => {
+    const rows = [
+      makeSetRow({ exercise_id: 'ex1', exercise_order: 1, set_number: 1 }),
+      makeSetRow({ exercise_id: 'ex1', exercise_order: 1, set_number: 2 }),
+      makeSetRow({ exercise_id: 'ex2', exercise_name: 'Squat', exercise_order: 2, set_number: 1 }),
+    ];
+    const result = buildExerciseList(rows);
+    expect(result).toHaveLength(2);
+    expect(result[0].sets).toHaveLength(2);
+    expect(result[1].sets).toHaveLength(1);
+  });
+
+  it('includes warmup set rows as exercises', () => {
+    const rows = [
+      makeSetRow({ exercise_id: 'w1', exercise_name: 'Arm Circles', section: 'warmup', exercise_order: 1, set_number: 1 }),
+    ];
+    const result = buildExerciseList(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].section).toBe('warmup');
+    expect(result[0].sets).toHaveLength(1);
+  });
+});
+
+describe('mergeWarmups', () => {
+  // AC1 & AC2: No duplicate warmups
+  it('skips warmup metadata that already exists in tracked exercises', () => {
+    const tracked = [
+      makeExercise({
+        exercise_id: 'w1',
+        exercise_name: 'Arm Circles',
+        section: 'warmup',
+        exercise_order: 1,
+        sets: [{ set_number: 1, planned_reps: '', weight: '', reps: '', effort: '', notes: '', saved: true, sheetRow: 2 }],
+      }),
+      makeExercise({ exercise_id: 'ex1', exercise_name: 'Bench Press', section: 'primary', exercise_order: 2 }),
+    ];
+    const warmupInfos = [
+      { exercise_id: 'w1', exercise_name: 'Arm Circles', exercise_order: 1 },
+    ];
+
+    const result = mergeWarmups(tracked, warmupInfos);
+    const warmups = result.filter((e) => e.exercise_id === 'w1');
+    expect(warmups).toHaveLength(1);
+    expect(warmups[0].sets).toHaveLength(1); // keeps the tracked version with sets
+  });
+
+  // AC3: Deletion integrity — each exercise has unique identity in merged list
+  it('produces exercises with unique exercise_id + exercise_order keys', () => {
+    const tracked = [
+      makeExercise({ exercise_id: 'w1', section: 'warmup', exercise_order: 1 }),
+      makeExercise({ exercise_id: 'ex1', section: 'primary', exercise_order: 2 }),
+    ];
+    const warmupInfos = [
+      { exercise_id: 'w1', exercise_name: 'Arm Circles', exercise_order: 1 },
+    ];
+
+    const result = mergeWarmups(tracked, warmupInfos);
+    const keys = result.map((e) => `${e.exercise_id}__${e.exercise_order}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  // AC4: Warmup-only templates
+  it('adds warmup metadata when no tracked exercises exist', () => {
+    const tracked: TrackerExercise[] = [];
+    const warmupInfos = [
+      { exercise_id: 'w1', exercise_name: 'Arm Circles', exercise_order: 1 },
+      { exercise_id: 'w2', exercise_name: 'Leg Swings', exercise_order: 2 },
+    ];
+
+    const result = mergeWarmups(tracked, warmupInfos);
+    expect(result).toHaveLength(2);
+    expect(result[0].section).toBe('warmup');
+    expect(result[1].section).toBe('warmup');
+  });
+
+  // AC5: Edit mode — same merge logic, warmups from set rows already tracked
+  it('handles edit mode where warmups are already in tracked from persisted sets', () => {
+    const tracked = [
+      makeExercise({
+        exercise_id: 'w1',
+        exercise_name: 'Arm Circles',
+        section: 'warmup',
+        exercise_order: 1,
+        sets: [{ set_number: 1, planned_reps: '', weight: '', reps: '', effort: '', notes: '', saved: true, sheetRow: 5 }],
+      }),
+      makeExercise({
+        exercise_id: 'w2',
+        exercise_name: 'Leg Swings',
+        section: 'warmup',
+        exercise_order: 2,
+        sets: [{ set_number: 1, planned_reps: '', weight: '', reps: '', effort: '', notes: '', saved: true, sheetRow: 6 }],
+      }),
+      makeExercise({ exercise_id: 'ex1', section: 'primary', exercise_order: 3 }),
+    ];
+    const warmupInfos = [
+      { exercise_id: 'w1', exercise_name: 'Arm Circles', exercise_order: 1 },
+      { exercise_id: 'w2', exercise_name: 'Leg Swings', exercise_order: 2 },
+    ];
+
+    const result = mergeWarmups(tracked, warmupInfos);
+    expect(result).toHaveLength(3);
+    expect(result.filter((e) => e.section === 'warmup')).toHaveLength(2);
+  });
+
+  it('preserves sort order by exercise_order', () => {
+    const tracked = [
+      makeExercise({ exercise_id: 'ex1', section: 'primary', exercise_order: 3 }),
+    ];
+    const warmupInfos = [
+      { exercise_id: 'w1', exercise_name: 'Arm Circles', exercise_order: 1 },
+    ];
+
+    const result = mergeWarmups(tracked, warmupInfos);
+    expect(result[0].exercise_order).toBe(1);
+    expect(result[1].exercise_order).toBe(3);
+  });
+});

--- a/frontend/src/components/workout/build-exercise-list.ts
+++ b/frontend/src/components/workout/build-exercise-list.ts
@@ -1,0 +1,74 @@
+import type { TrackerExercise } from './exercise-row';
+import type { SetWithRow, Effort } from '../../api/types';
+
+interface WarmupExerciseInfo {
+  exercise_id: string;
+  exercise_name: string;
+  exercise_order: number;
+}
+
+/** Build TrackerExercise list from flat set rows. */
+export function buildExerciseList(setRows: SetWithRow[]): TrackerExercise[] {
+  const map = new Map<string, TrackerExercise>();
+
+  for (const s of setRows) {
+    const key = `${s.exercise_id}__${s.exercise_order}`;
+    let ex = map.get(key);
+    if (!ex) {
+      ex = {
+        exercise_id: s.exercise_id,
+        exercise_name: s.exercise_name,
+        section: s.section,
+        exercise_order: s.exercise_order,
+        sets: [],
+        quickFillWeight: '',
+        quickFillReps: '',
+        quickFillEffort: '',
+      };
+      map.set(key, ex);
+    }
+    ex.sets.push({
+      set_number: s.set_number,
+      planned_reps: s.planned_reps,
+      weight: s.weight,
+      reps: s.reps,
+      effort: s.effort as Effort | '',
+      notes: s.notes,
+      saved: s.sheetRow > 0,
+      sheetRow: s.sheetRow,
+    });
+  }
+
+  const list = Array.from(map.values()).sort((a, b) => a.exercise_order - b.exercise_order);
+  for (const ex of list) {
+    ex.sets.sort((a, b) => a.set_number - b.set_number);
+  }
+  return list;
+}
+
+/**
+ * Merge warmup exercise metadata with tracked exercises built from set rows.
+ * Warmups that already exist in `tracked` (by exercise_id + exercise_order) are skipped
+ * to avoid duplication.
+ */
+export function mergeWarmups(
+  tracked: TrackerExercise[],
+  warmupInfos: WarmupExerciseInfo[],
+): TrackerExercise[] {
+  const trackedKeys = new Set(tracked.map((e) => `${e.exercise_id}__${e.exercise_order}`));
+
+  const newWarmups: TrackerExercise[] = warmupInfos
+    .filter((w) => !trackedKeys.has(`${w.exercise_id}__${w.exercise_order}`))
+    .map((w) => ({
+      exercise_id: w.exercise_id,
+      exercise_name: w.exercise_name,
+      section: 'warmup',
+      exercise_order: w.exercise_order,
+      sets: [],
+      quickFillWeight: '',
+      quickFillReps: '',
+      quickFillEffort: '',
+    }));
+
+  return [...newWarmups, ...tracked].sort((a, b) => a.exercise_order - b.exercise_order);
+}

--- a/frontend/src/components/workout/workout-tracker.tsx
+++ b/frontend/src/components/workout/workout-tracker.tsx
@@ -15,51 +15,11 @@ import { applyQuickFillWeight, applyQuickFillReps, applyQuickFillEffort } from '
 import { applyCopyDown } from './copy-down';
 import { isWarmupExercise } from './warmup';
 import { applyChangeSection, applyMoveUp, applyMoveDown } from './section-management';
+import { buildExerciseList, mergeWarmups } from './build-exercise-list';
 
 interface Props {
   workoutId: string;
   workoutName: string;
-}
-
-/** Build TrackerExercise list from flat set rows. */
-function buildExerciseList(setRows: typeof activeWorkoutSets.value): TrackerExercise[] {
-  const map = new Map<string, TrackerExercise>();
-
-  for (const s of setRows) {
-    // Key by exercise_id + exercise_order to distinguish same exercise in different sections
-    const key = `${s.exercise_id}__${s.exercise_order}`;
-    let ex = map.get(key);
-    if (!ex) {
-      ex = {
-        exercise_id: s.exercise_id,
-        exercise_name: s.exercise_name,
-        section: s.section,
-        exercise_order: s.exercise_order,
-        sets: [],
-        quickFillWeight: '',
-        quickFillReps: '',
-        quickFillEffort: '',
-      };
-      map.set(key, ex);
-    }
-    ex.sets.push({
-      set_number: s.set_number,
-      planned_reps: s.planned_reps,
-      weight: s.weight,
-      reps: s.reps,
-      effort: s.effort as Effort | '',
-      notes: s.notes,
-      saved: s.sheetRow > 0,
-      sheetRow: s.sheetRow,
-    });
-  }
-
-  // Sort exercises by order, sets by set_number
-  const list = Array.from(map.values()).sort((a, b) => a.exercise_order - b.exercise_order);
-  for (const ex of list) {
-    ex.sets.sort((a, b) => a.set_number - b.set_number);
-  }
-  return list;
 }
 
 export function WorkoutTracker({ workoutId, workoutName }: Props) {
@@ -97,21 +57,12 @@ export function WorkoutTracker({ workoutId, workoutName }: Props) {
     return () => window.removeEventListener('online', handleOnline);
   }, [token]);
 
-  // Initialize from signal, merging warmup exercises (list-only, no sets)
+  // Initialize from signal, merging warmup exercises (list-only, no sets).
+  // Warmups already present in activeWorkoutSets (as persisted set rows) are
+  // skipped from activeWarmupExercises to avoid duplication.
   useEffect(() => {
     const tracked = buildExerciseList(activeWorkoutSets.value);
-    const warmups: TrackerExercise[] = activeWarmupExercises.value.map((w) => ({
-      exercise_id: w.exercise_id,
-      exercise_name: w.exercise_name,
-      section: 'warmup',
-      exercise_order: w.exercise_order,
-      sets: [],
-      quickFillWeight: '',
-      quickFillReps: '',
-      quickFillEffort: '',
-    }));
-    const merged = [...warmups, ...tracked].sort((a, b) => a.exercise_order - b.exercise_order);
-    setExerciseList(merged);
+    setExerciseList(mergeWarmups(tracked, activeWarmupExercises.value));
   }, []);
 
   // Debounced save for a specific set (disabled in edit mode)


### PR DESCRIPTION
Closes #93

## Changes
- Extracted `buildExerciseList` and new `mergeWarmups` into `build-exercise-list.ts`
- `mergeWarmups` filters out warmup metadata entries whose key (`exercise_id__exercise_order`) already exists in the tracked list, preventing duplication
- Updated `workout-tracker.tsx` to use the extracted functions
- Added 7 tests covering all 5 ACs (dedup from template, builder, deletion integrity, warmup-only templates, edit mode)

## Root Cause
`prepopulateSetsFromTemplate` stored warmups in both `activeWorkoutSets` (as persisted set rows) and `activeWarmupExercises` (as metadata). The tracker merged both without deduplication, creating duplicate entries with the same identity key.